### PR TITLE
Add mkdocstrings for automatic API reference generation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,4 @@
+# API Reference
+
+<!-- ::: calt.dataset_generator.sympy.dataset_generator -->
+::: calt.data_loader.data_loader.load_data

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: CALT library
 site_description: Documentation for CALT library, a library for computational algebra using Transformers
 site_dir: site
-site_url: https://calt.github.io/
+site_url: https://hiroshikera.github.io/calt/
 
 repo_url: https://github.com/HiroshiKERA/calt
 
@@ -68,6 +68,7 @@ extra_javascript:
 nav:
   - User Guide:
     - Welcome: README.md
+    - API Reference: api.md
 
 exclude_docs: |
   node_modules
@@ -85,9 +86,31 @@ plugins:
       handlers:
         python:
           options:
-            docstring_style: google
-            show_root_heading: true
-            show_source: true
+            # Which docstring style to interpret
+            docstring_style: numpy        # or numpy / sphinx
+            # Rendering style for Parameters/Returns, etc.
+            docstring_section_style: table # or list / spacy
+            # Headings and signatures
+            show_signature: true
+            separate_signature: true
+            show_signature_annotations: true
+            line_length: 80
+            heading_level: 2
+            show_root_heading: false
+            show_root_toc_entry: true
+            # Member selection and ordering
+            filters: ["!^_[^_]"]           # Exclude members starting with _, keep dunder (default)
+            group_by_category: true
+            members_order: source          # Display in source order
+            show_submodules: false
+            # To include inherited members
+            # inherited_members: true
+            # To merge __init__ docstring into class docstring
+            merge_init_into_class: true
+            docstring_options:
+              ignore_init_summary: true    # Omit one-line summary of __init__
+          # Specify search path when using src layout
+          paths: [src]
   - llmstxt:
       sections:
         User Guide:
@@ -96,7 +119,7 @@ plugins:
         Examples:
           - examples/**/*.md
         API Reference:
-          - api-reference/*.md
+          - api.md
 
 extra:
   social:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block site_meta %}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    {% if page.meta and page.meta.description %}
+      <meta name="description" content="{{ page.meta.description }}">
+    {% elif config.site_description %}
+      <meta name="description" content="{{ config.site_description }}">
+    {% endif %}
+    {% if page.meta and page.meta.author %}
+      <meta name="author" content="{{ page.meta.author }}">
+    {% elif config.site_author %}
+      <meta name="author" content="{{ config.site_author }}">
+    {% endif %}
+    {% if page.canonical_url %}
+      <link rel="canonical" href="{{ page.canonical_url }}">
+    {% endif %}
+    {% if page.previous_page %}
+      <link rel="prev" href="{{ page.previous_page.url | url }}">
+    {% endif %}
+    {% if page.next_page %}
+      <link rel="next" href="{{ page.next_page.url | url }}">
+    {% endif %}
+    {% if "rss" in config.plugins %}
+      <link rel="alternate" type="application/rss+xml" title="{{ lang.t('rss.created') }}" href="{{ 'feed_rss_created.xml' | url }}">
+      <link rel="alternate" type="application/rss+xml" title="{{ lang.t('rss.updated') }}" href="{{ 'feed_rss_updated.xml' | url }}">
+    {% endif %}
+    <link rel="icon" href="{{ config.theme.favicon_png | url }}" sizes="any">
+    <link rel="icon" href="{{ config.theme.favicon | url }}" type="image/svg+xml">
+    <meta name="generator" content="mkdocs-{{ mkdocs_version }}, mkdocs-material-9.6.14">
+{% endblock %}

--- a/overrides/partials/logo.html
+++ b/overrides/partials/logo.html
@@ -1,0 +1,8 @@
+<!-- Logo -->
+{% if config.theme.logo %}
+  <img src="{{ config.theme.logo | url }}" alt="logo" class="logo-light" />
+  <img src="{{ config.theme.logo_dark | url }}" alt="logo" class="logo-dark" />
+{% else %}
+  {% set icon = config.theme.icon.logo or "material/library" %}
+  {% include ".icons/" ~ icon ~ ".svg" %}
+{% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "mkdocstrings-python~=1.16.10",
     "mkdocs-llmstxt~=0.2.0",
     "strands-agents~=0.1.0",
+    "mkdocstrings[python]>=0.29.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -161,6 +161,7 @@ dev = [
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-macros-plugin" },
     { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "pydantic" },
@@ -188,6 +189,7 @@ dev = [
     { name = "mkdocs-llmstxt", specifier = "~=0.2.0" },
     { name = "mkdocs-macros-plugin", specifier = "~=1.3.7" },
     { name = "mkdocs-material", specifier = "~=9.6.12" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
     { name = "mkdocstrings-python", specifier = "~=1.16.10" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
@@ -929,6 +931,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/e8/d22922664a627a0d3d7ff4a6ca95800f5dde54f411982591b4621a76225d/mkdocstrings-0.29.1.tar.gz", hash = "sha256:8722f8f8c5cd75da56671e0a0c1bbed1df9946c0cef74794d6141b34011abd42", size = 1212686 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/14/22533a578bf8b187e05d67e2c1721ce10e3f526610eebaf7a149d557ea7a/mkdocstrings-0.29.1-py3-none-any.whl", hash = "sha256:37a9736134934eea89cbd055a513d40a020d87dfcae9e3052c2a6b8cd4af09b6", size = 1631075 },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR introduces mkdocstrings to enable semi-automatic generation of library class and method references from docstrings.

## Changes
Added mkdocs and mkdocstrings to the project environment.
Prepared api.md for future addition of API references (to be completed in a separate branch).
Noted the need to standardize docstring style across the codebase for consistent documentation output.

## Notes
API references will be generated based on existing docstrings, so aligning the format (e.g., Google-style or NumPy-style) is important.
The actual reference content in api.md will be added in a follow-up PR.

