### PR TITLE
Feature/backward generation

### DIFF
--- a/src/calt/dataset/sagemath/dataset_generator.py
+++ b/src/calt/dataset/sagemath/dataset_generator.py
@@ -74,8 +74,22 @@ def setup_logging():
                 handler.setFormatter(logging.Formatter("%(message)s"))
 
 
-def _worker_init():
+# Worker-process globals. The instance generator and statistics calculator are
+# transmitted ONCE per worker — via the joblib initializer (spawn/loky) or by
+# fork inheritance (multiprocessing on Linux) — instead of being pickled with
+# every task. Passing them per task pickles the (possibly large) generator
+# closure for each sample; see issue #37 (up to ~469x slowdown).
+_WORKER_INSTANCE_GENERATOR = None
+_WORKER_STATISTICS_CALCULATOR = None
+
+
+def _worker_init(instance_generator=None, statistics_calculator=None):
     setup_logging()
+    global _WORKER_INSTANCE_GENERATOR, _WORKER_STATISTICS_CALCULATOR
+    if instance_generator is not None:
+        _WORKER_INSTANCE_GENERATOR = instance_generator
+    if statistics_calculator is not None:
+        _WORKER_STATISTICS_CALCULATOR = statistics_calculator
 
 
 # Setup logging for this module
@@ -177,12 +191,17 @@ class DatasetGenerator:
         self,
         sample_index: int,
         tag: str,
-        instance_generator: Callable,
-        statistics_calculator: Callable | None = None,
     ) -> tuple[
         StringProblemOrAnswer, StringProblemOrAnswer, StatisticsDict | None, float
     ]:
-        """Generate a single sample using the provided instance generator."""
+        """Generate a single sample using the worker's instance generator.
+
+        The instance generator and statistics calculator are read from
+        worker-process globals set once by ``_worker_init`` (see issue #37),
+        rather than received as per-task arguments.
+        """
+        instance_generator = _WORKER_INSTANCE_GENERATOR
+        statistics_calculator = _WORKER_STATISTICS_CALCULATOR
         # Generate a unique seed for this job
         seed = self._generate_seed(sample_index, tag)
 
@@ -242,6 +261,12 @@ class DatasetGenerator:
                 )
                 self.logger.info("Starting parallel processing...")
 
+            # Make the generator/statistics calculator available without
+            # per-task pickling: set them in this process (used by the inline /
+            # n_jobs=1 path and inherited by forked workers) and transmit them
+            # once per worker through the initializer (see issue #37).
+            _worker_init(instance_generator, statistics_calculator)
+
             # Generate samples for current batch in parallel using joblib
             try:
                 results = Parallel(
@@ -249,13 +274,9 @@ class DatasetGenerator:
                     backend=self.backend,
                     verbose=self.verbose,
                     initializer=_worker_init,
+                    initargs=(instance_generator, statistics_calculator),
                 )(
-                    delayed(self._generate_sample)(
-                        batch_start + i,
-                        tag,
-                        instance_generator,
-                        statistics_calculator,
-                    )
+                    delayed(self._generate_sample)(batch_start + i, tag)
                     for i in range(current_batch_size)
                 )
             except (MemoryError, OSError) as e:

--- a/src/calt/dataset/sagemath/utils/ideal_invariant_transformer/__init__.py
+++ b/src/calt/dataset/sagemath/utils/ideal_invariant_transformer/__init__.py
@@ -1,0 +1,17 @@
+"""Ideal-invariant transforms ("backward" data generation, step ii).
+
+Given a basis ``G`` of an ideal ``I`` (e.g. sampled by ``ideal_sampler``), these
+transforms produce a generating set ``F`` of the *same* ideal ``I = <F> = <G>``,
+yielding a training pair ``(F, G)`` whose target ``G`` is the basis of ``<F>``.
+
+  - Gröbner (NeurIPS'24): ``F = U · P · A · G`` with unimodular upper-triangular
+    ``U, A`` and a permutation ``P`` (Bruhat-decomposition transform).
+    See :class:`GroebnerIdealTransformer`.
+  - Border (NeurIPS'25): ``F = A · G`` with a random matrix ``A`` — a generalized
+    version of the above. See :class:`BorderIdealTransformer`.
+"""
+
+from .border import BorderIdealTransformer
+from .groebner import GroebnerIdealTransformer
+
+__all__ = ["GroebnerIdealTransformer", "BorderIdealTransformer"]

--- a/src/calt/dataset/sagemath/utils/ideal_invariant_transformer/border.py
+++ b/src/calt/dataset/sagemath/utils/ideal_invariant_transformer/border.py
@@ -1,0 +1,121 @@
+"""Ideal-invariant transform for border-basis data (NeurIPS'25).
+
+Reference
+---------
+Kera et al. (NeurIPS 2025). Original implementation:
+``backward_basis_transformation`` in
+https://github.com/HiroshiKERA/OracleBorderBasis
+(``src/dataset/generators/border_basis_generator.py``).
+
+This is the *generalized* version of the Gröbner Bruhat transform: given a basis
+``G`` (an ``n x 1`` column over the polynomial ring), draw a random ``m x n``
+matrix ``A`` (``m > n``) and set
+
+    F = A · G,
+
+a generating set of ``m`` polynomials.
+
+Default (``identity_block=False``) reproduces the reference exactly: ``A`` is
+sampled fully at random. With **constant** (degree-0) entries this is exactly an
+ideal-invariant transform — ``F`` is then a set of field-linear combinations of
+the border basis, so ``<F> = <G>`` (empirically 100%). With higher-degree
+entries the invariance is only generic (~90-95%). Set ``identity_block=True`` to
+pin the top ``n`` rows of ``A`` to the identity, which makes ``<F> = <G>`` exact
+for any entry degree (``F`` then contains ``G`` verbatim plus random combinations).
+"""
+
+from sage.all import identity_matrix, matrix, randint
+
+from ..polynomial_sampler import PolynomialSampler, compute_max_coefficient
+
+
+def _max_abs_coeff_in_matrix(M) -> float:
+    best = 0
+    for entry in M.list():
+        if entry != 0:
+            best = max(best, compute_max_coefficient(entry))
+    return best
+
+
+class BorderIdealTransformer:
+    """Apply the generalized ideal-invariant transform ``F = A · G``.
+
+    Args:
+        ring: SageMath ``PolynomialRing`` (must match ``G``).
+        max_size: Maximum number of generators in ``F``.
+        identity_block: If False (default), reproduces the reference: ``A`` is
+            fully random (exactly ideal-invariant with degree-0/constant entries;
+            generic otherwise). If True, the first ``n`` rows of ``A`` are the
+            identity so that ``<F> = <G>`` holds exactly for any entry degree.
+        max_degree, min_degree, max_num_terms, max_coeff, num_bound,
+        degree_sampling, term_sampling, strictly_conditioned: forwarded to the
+            ``PolynomialSampler`` used for the rows of ``A`` (``max_degree=0``
+            gives the exactly-invariant constant-coefficient transform).
+        density, coeff_bound, max_iter: as in ``GroebnerIdealTransformer``.
+    """
+
+    def __init__(
+        self,
+        ring,
+        max_size: int,
+        identity_block: bool = False,
+        max_degree: int = 1,
+        min_degree: int = 0,
+        max_num_terms: int | None = None,
+        max_coeff: int | None = None,
+        num_bound: int | None = None,
+        degree_sampling: str = "uniform",
+        term_sampling: str = "uniform",
+        strictly_conditioned: bool = True,
+        density: float = 1.0,
+        coeff_bound: int = 100,
+        max_iter: int = 100,
+    ):
+        self.ring = ring
+        self.max_size = max_size
+        self.identity_block = identity_block
+        self.density = density
+        self.coeff_bound = coeff_bound
+        self.max_iter = max_iter
+        self._sampler = PolynomialSampler(
+            ring=ring,
+            order=None,
+            max_degree=max_degree,
+            min_degree=min_degree,
+            max_num_terms=max_num_terms,
+            max_coeff=max_coeff,
+            num_bound=num_bound,
+            degree_sampling=degree_sampling,
+            term_sampling=term_sampling,
+            strictly_conditioned=strictly_conditioned,
+            nonzero_instance=True,
+        )
+
+    def transform(self, G: list) -> list:
+        """Return a generating set ``F`` (list of ring elements) with ``<F> = <G>``."""
+        ring = self.ring
+        n = len(G)
+        SG = matrix(ring, n, 1, list(G))
+        is_finite = ring.base_ring().is_finite()
+
+        F = None
+        for _ in range(self.max_iter):
+            # m = target number of generators of F (m > n), as in the reference.
+            m = randint(0, max(0, self.max_size - n)) + n + 1
+            if self.identity_block:
+                # Top n rows = identity (keep G verbatim), then m - n random rows.
+                extra = self._sampler.sample(
+                    num_samples=1, size=(m - n, n), density=self.density
+                )[0]
+                A = identity_matrix(ring, n).stack(extra)
+            else:
+                # Reference: A is a fully random m x n matrix.
+                A = self._sampler.sample(
+                    num_samples=1, size=(m, n), density=self.density
+                )[0]
+            F = A * SG
+
+            if is_finite or _max_abs_coeff_in_matrix(F) <= self.coeff_bound:
+                break
+
+        return [F[i, 0] for i in range(F.nrows())]

--- a/src/calt/dataset/sagemath/utils/ideal_invariant_transformer/groebner.py
+++ b/src/calt/dataset/sagemath/utils/ideal_invariant_transformer/groebner.py
@@ -1,0 +1,128 @@
+"""Ideal-invariant transform for Gröbner-basis data (NeurIPS'24).
+
+Reference
+---------
+Kera et al., "Learning to Compute Gröbner Bases" (NeurIPS 2024). Original
+implementation: ``random_non_gb`` in
+https://github.com/HiroshiKERA/transformer-groebner (``src/dataset/groebner.sage``).
+
+Given a basis ``G`` (as an ``n x 1`` column over the polynomial ring), draw a
+random ideal-preserving transform
+
+    F = U · P · A · G
+
+where ``A`` is an ``m x n`` unimodular upper-triangular polynomial matrix
+(``m >= n``), ``U`` is an ``m x m`` unimodular upper-triangular polynomial
+matrix, and ``P`` is an ``m x m`` permutation matrix. The result ``F`` is a
+generating set of ``m`` polynomials with ``<F> = <G>`` but, in general, ``F`` is
+not a Gröbner basis — exactly the (F, G) training pair the model learns from.
+"""
+
+from sage.all import Permutation, Permutations, matrix, randint
+
+from ..polynomial_sampler import PolynomialSampler, compute_max_coefficient
+
+
+def random_permutation_matrix(m: int):
+    """Random ``m x m`` permutation matrix (SageMath)."""
+    perm = Permutations(list(range(1, m + 1))).random_element()
+    return matrix(Permutation(perm))
+
+
+def _max_abs_coeff_in_matrix(M) -> float:
+    """Largest absolute coefficient appearing in any polynomial entry of ``M``."""
+    best = 0
+    for entry in M.list():
+        if entry != 0:
+            best = max(best, compute_max_coefficient(entry))
+    return best
+
+
+def _unimodular(sampler, rows: int, cols: int, density: float):
+    """Reference-faithful unimodular matrix (transformer-groebner convention).
+
+    1 on the diagonal, 0 strictly above it, random below. For a rectangular
+    ``rows > cols`` matrix the extra bottom rows lie below the diagonal and so
+    stay random — unlike zeroing the strict-lower part, which would make those
+    rows all-zero and produce zero generators in ``F``.
+    """
+    M = sampler.sample(num_samples=1, size=(rows, cols), density=density)[0]
+    for i in range(rows):
+        for j in range(cols):
+            if i == j:
+                M[i, j] = 1
+            elif i < j:
+                M[i, j] = 0
+    return M
+
+
+class GroebnerIdealTransformer:
+    """Apply the Bruhat-decomposition ideal-invariant transform ``F = U·P·A·G``.
+
+    Args:
+        ring: SageMath multivariate ``PolynomialRing`` (must match ``G``).
+        max_size: Maximum number of generators in ``F`` (``>= n = len(G)``).
+        max_degree, min_degree, max_num_terms, max_coeff, num_bound,
+        degree_sampling, term_sampling, strictly_conditioned: forwarded to the
+            ``PolynomialSampler`` used for the random matrices.
+        density: Probability of non-zero off-diagonal entries in the matrices.
+        coeff_bound: Over infinite fields (QQ/ZZ/RR), retry while the largest
+            coefficient in ``F`` exceeds this bound (coefficient-swell guard).
+        max_iter: Maximum number of retries for the coefficient bound.
+    """
+
+    def __init__(
+        self,
+        ring,
+        max_size: int,
+        max_degree: int = 1,
+        min_degree: int = 1,
+        max_num_terms: int | None = None,
+        max_coeff: int | None = None,
+        num_bound: int | None = None,
+        degree_sampling: str = "uniform",
+        term_sampling: str = "uniform",
+        strictly_conditioned: bool = True,
+        density: float = 1.0,
+        coeff_bound: int = 100,
+        max_iter: int = 100,
+    ):
+        self.ring = ring
+        self.max_size = max_size
+        self.density = density
+        self.coeff_bound = coeff_bound
+        self.max_iter = max_iter
+        self._sampler = PolynomialSampler(
+            ring=ring,
+            order=None,  # PolynomialSampler forbids ring + order together
+            max_degree=max_degree,
+            min_degree=min_degree,
+            max_num_terms=max_num_terms,
+            max_coeff=max_coeff,
+            num_bound=num_bound,
+            degree_sampling=degree_sampling,
+            term_sampling=term_sampling,
+            strictly_conditioned=strictly_conditioned,
+            nonzero_instance=True,
+        )
+
+    def transform(self, G: list) -> list:
+        """Return a generating set ``F`` (list of ring elements) with ``<F> = <G>``."""
+        ring = self.ring
+        n = len(G)
+        SG = matrix(ring, n, 1, list(G))
+        is_finite = ring.base_ring().is_finite()
+
+        F = None
+        for _ in range(self.max_iter):
+            m = randint(0, self.max_size - n) + n
+            A = _unimodular(self._sampler, m, n, self.density)
+            U = _unimodular(self._sampler, m, m, self.density)
+            P = random_permutation_matrix(m)
+
+            F = U * P * A * SG
+
+            if is_finite or _max_abs_coeff_in_matrix(F) <= self.coeff_bound:
+                break
+
+        return [F[i, 0] for i in range(F.nrows())]

--- a/src/calt/dataset/sagemath/utils/ideal_sampler/__init__.py
+++ b/src/calt/dataset/sagemath/utils/ideal_sampler/__init__.py
@@ -1,0 +1,17 @@
+"""Direct samplers of ideal bases ("backward" data generation).
+
+Instead of sampling a generating set F and *computing* a basis G (the forward
+direction), these samplers draw a basis G directly, following the algorithms in:
+
+  - Gröbner bases in shape position — Kera et al., "Learning to Compute Gröbner
+    Bases" (NeurIPS 2024). See :class:`GroebnerBasisSampler`.
+  - Border bases — Kera et al. (NeurIPS 2025). See :class:`BorderBasisSampler`.
+
+Pair these with an ideal-invariant transform (``ideal_invariant_transformer``)
+to obtain a generating set F of the same ideal, giving a training pair (F, G).
+"""
+
+from .border import BorderBasisSampler
+from .groebner import GroebnerBasisSampler
+
+__all__ = ["GroebnerBasisSampler", "BorderBasisSampler"]

--- a/src/calt/dataset/sagemath/utils/ideal_sampler/border.py
+++ b/src/calt/dataset/sagemath/utils/ideal_sampler/border.py
@@ -1,0 +1,307 @@
+"""Direct sampling of border bases of zero-dimensional ideals (NeurIPS'25).
+
+Reference
+---------
+Kera et al. (NeurIPS 2025). Original implementation: ``BorderBasisSampler`` /
+``random_border_basis`` in
+https://github.com/HiroshiKERA/OracleBorderBasis
+(``src/border_basis_lib/border_basis_sampling.py``).
+
+Idea
+----
+A border basis of a zero-dimensional ideal is determined by an *order ideal*
+``O`` (a finite, divisor-closed set of monomials) and its *border* ``B`` (the
+monomials ``x_i · o`` not already in ``O``). We:
+
+  1. sample a random order ideal ``O`` (by recursively splitting the staircase),
+  2. compute its border ``B``,
+  3. draw ``|O|`` random evaluation points ``P`` so that the order-ideal
+     monomials are linearly independent there, and
+  4. solve a linear system (kernel of ``[B(P) | O(P)]``) to obtain the border
+     basis ``G`` whose vanishing ideal at ``P`` has ``O`` as a basis of the
+     quotient.
+
+``BorderBasisSampler.sample`` returns the basis ``G`` (a list of ring elements);
+``random_border_basis`` returns the full record (basis, border, order, points).
+"""
+
+# ``O`` (order ideal), ``B`` (border), ``V`` (kernel) follow the paper's math
+# notation, so we allow ruff's "ambiguous variable name" rule here.
+# ruff: noqa: E741
+import itertools as it
+from copy import deepcopy
+from dataclasses import dataclass
+from random import choice, shuffle
+
+import numpy as np
+from sage.all import QQ, Matrix, MatrixSpace, Partitions
+
+
+# --------------------------------------------------------------------------- #
+# Helpers (ported from border_basis_lib/utils.py)                              #
+# --------------------------------------------------------------------------- #
+def border(order_ideal):
+    """Border of an order ideal: monomials ``x_i · o`` (o in O) not already in O."""
+    span_variables = order_ideal[0].args()
+    B = []
+    for x in span_variables:
+        B += [x * o for o in order_ideal if x * o not in order_ideal]
+    return sorted(set(B))
+
+
+def subs(F, P):
+    """Evaluate polynomials ``F`` at the rows of point-matrix ``P``.
+
+    Returns a ``(num_points x num_polys)`` matrix over the base field.
+    """
+    field = P[0, 0].base_ring()
+    num_points = P.nrows()
+    FP = [f(*p) for p, f in it.product(P, F)]
+    return MatrixSpace(field, num_points, len(F))(FP)
+
+
+def is_regular(M):
+    """True iff ``M`` has full rank ``min(rows, cols)``."""
+    return M.rank() == min(M.ncols(), M.nrows())
+
+
+def keyword_for_numbound(field, bound):
+    """Random-element kwargs bounding coefficient size (only meaningful over QQ)."""
+    return {"num_bound": bound} if field == QQ else {}
+
+
+# --------------------------------------------------------------------------- #
+# Staircase geometry                                                          #
+# --------------------------------------------------------------------------- #
+@dataclass
+class Segment:
+    """An axis-aligned segment in n-dim space defined by two endpoints."""
+
+    endpoints: list
+
+    def __post_init__(self):
+        self.lb = np.array(np.minimum.reduce(self.endpoints), dtype=int)
+        self.ub = np.array(np.maximum.reduce(self.endpoints), dtype=int)
+        self.n = len(self.lb)
+
+    def __hash__(self):
+        return hash((tuple(self.lb), tuple(self.ub)))
+
+
+@dataclass
+class NeighborSegments:
+    """Collection of segments meeting at an intersecting point."""
+
+    segments: list
+    intersecting_point: np.ndarray
+
+    def __post_init__(self):
+        self.n = self.segments[0].n
+        max_point = np.vstack([segment.ub for segment in self.segments])
+        self.max_point = np.min(max_point + np.eye(self.n, dtype=int) * 100000, axis=0)
+        self.valid = np.sum(
+            self.max_point != self.intersecting_point
+        ) > 1 and not np.all(self.max_point - self.intersecting_point <= 1)
+
+    def sampling(self) -> np.ndarray:
+        nondegenerated = np.array(self.intersecting_point < self.max_point + 1)
+        point = self.intersecting_point.copy()
+        point[nondegenerated] = np.random.randint(
+            self.intersecting_point[nondegenerated], self.max_point[nondegenerated] + 1
+        )
+        return point
+
+    def split_at(self, splitpoint: np.ndarray) -> list:
+        new_segment = Segment(deepcopy([self.intersecting_point, splitpoint]))
+        new_neighborsegments = []
+        for i in range(self.n):
+            new_segments = []
+            for j, segment in enumerate(self.segments):
+                if i != j:
+                    lb = segment.lb
+                    lb[j] = splitpoint[j]
+                    ub = segment.ub
+                    new_segments.append(Segment([lb, ub]))
+                else:
+                    new_segments.append(deepcopy(new_segment))
+            new_intersecting_point = self.intersecting_point + np.eye(self.n)[i] * (
+                splitpoint[i] - self.intersecting_point[i]
+            )
+            new_neighborsegments.append(
+                NeighborSegments(deepcopy(new_segments), new_intersecting_point)
+            )
+        return new_neighborsegments
+
+
+class BorderBasisSampler:
+    """Sample border bases of zero-dimensional ideals (NeurIPS'25)."""
+
+    def __init__(self, ring):
+        self.ring = ring
+        self.n = ring.ngens()
+
+    # ---- order-ideal sampling -------------------------------------------- #
+    def hypercube_points(self, u, v, exclude_max: bool = True) -> list:
+        u, v = np.minimum(u, v), np.maximum(u, v)
+        grid_ranges = [np.arange(u[i], v[i] + 1, dtype=int) for i in range(len(u))]
+        return [
+            tuple(map(int, p))
+            for p in it.product(*grid_ranges)
+            if not (exclude_max and np.array_equal(p, v))
+        ]
+
+    def span_order_ideal(self, neighbor_segments: list) -> list:
+        order_ideal = []
+        for ns in neighbor_segments:
+            order_ideal.extend(
+                deepcopy(
+                    self.hypercube_points(
+                        ns.intersecting_point, ns.max_point, exclude_max=False
+                    )
+                )
+            )
+        return order_ideal
+
+    def sample_order_ideal(self, degree_bounds, max_iters: int = 100) -> list:
+        origin = np.zeros(self.n, dtype=int)
+        max_point = np.array(degree_bounds)
+
+        S = []
+        for i in range(self.n):
+            endpoint = max_point.copy()
+            endpoint[i] = 0
+            S.append(Segment([origin, endpoint]))
+
+        N = [NeighborSegments(deepcopy(S), origin)]
+        T = []
+
+        O_axis = []
+        for i in range(self.n):
+            canonical_basis = np.eye(self.n, dtype=int)[i]
+            O_axis.extend(
+                self.hypercube_points(
+                    origin, canonical_basis * degree_bounds[i], exclude_max=False
+                )
+            )
+
+        for i in range(max_iters):
+            if i == max_iters - 1 or not N:
+                break
+            neighbor_segment = N.pop()
+            splitpoint = neighbor_segment.sampling()
+            new_neighborsegments = [
+                ns for ns in neighbor_segment.split_at(splitpoint) if ns.valid
+            ]
+            neighbor_segment.max_point = splitpoint
+            T.append(neighbor_segment)
+            N.extend(new_neighborsegments)
+            shuffle(N)
+
+        O = list(set(O_axis + self.span_order_ideal(T)))
+        O.sort(key=lambda x: (-sum(x), *reversed(x)))  # grevlex
+        return O
+
+    def random_order_ideal(
+        self, degree_bounds, total_degree_bound=None, degree_lower_bounds=None
+    ) -> list:
+        if degree_lower_bounds is None:
+            degree_lower_bounds = 0
+        if total_degree_bound is None:
+            upper_bounds = np.random.randint(
+                degree_lower_bounds, np.array(degree_bounds) + 1
+            )
+        else:
+            random_total_degree = np.random.randint(1, total_degree_bound + 1)
+            partitions = list(
+                Partitions(
+                    random_total_degree, max_length=self.n, max_part=max(degree_bounds)
+                )
+            )
+            partition = list(choice(partitions))
+            partition = partition + [0] * (self.n - len(partition))
+            shuffle(partition)
+            upper_bounds = partition
+        return self.sample_order_ideal(upper_bounds)
+
+    # ---- border basis from order ideal ----------------------------------- #
+    def compute_border_basis(self, B, O, P):
+        ring = self.ring
+        O = [ring(o) for o in O]
+        OP = subs(O, P)
+        if not is_regular(OP):
+            return None, False
+        B = [ring(b) for b in B]
+        BP = subs(B, P)
+        M = BP.augment(OP)
+        V = M.transpose().kernel().basis()
+        return V, True
+
+    def random_border_basis(
+        self,
+        degree_bounds,
+        max_sampling: int = 100,
+        total_degree_bound=None,
+        degree_lower_bounds=None,
+    ) -> dict:
+        assert len(degree_bounds) == self.n
+        ring = self.ring
+
+        tdb = None if total_degree_bound is None else total_degree_bound - 1
+        O = self.random_order_ideal(
+            np.array(degree_bounds) - 1,
+            total_degree_bound=tdb,
+            degree_lower_bounds=degree_lower_bounds,
+        )
+        O = [ring.monomial(*o) for o in O]
+        B = border(O)
+        B_exponents = sorted(
+            (t.exponents()[0] for t in B), key=lambda x: (-sum(x), *reversed(x))
+        )
+        B = [ring.monomial(*e) for e in B_exponents]
+
+        MSpace = MatrixSpace(ring.base_ring(), len(O), self.n)
+        success = False
+        P = None
+        for i in range(max_sampling):
+            if i == max_sampling - 1:
+                break
+            P = MSpace.random_element(**keyword_for_numbound(ring.base_ring(), 10))
+            V, success = self.compute_border_basis(B, O, P)
+            if success:
+                break
+
+        G = []
+        if success:
+            G = (Matrix(B + O) * Matrix(V).T)[0]
+            G = [ring(g) for g in G]
+
+        return {
+            "basis": G,
+            "order_coeff": V if success else None,
+            "border": B,
+            "order": O,
+            "points": P,
+            "success": success,
+        }
+
+    def sample(
+        self,
+        num_samples: int,
+        degree_bounds,
+        total_degree_bound=None,
+        max_sampling: int = 100,
+    ) -> list:
+        """Return ``num_samples`` border bases (each a list of ring elements).
+
+        Samples are retried until a valid border basis is found.
+        """
+        out = []
+        while len(out) < num_samples:
+            rec = self.random_border_basis(
+                degree_bounds,
+                max_sampling=max_sampling,
+                total_degree_bound=total_degree_bound,
+            )
+            if rec["success"]:
+                out.append(rec["basis"])
+        return out

--- a/src/calt/dataset/sagemath/utils/ideal_sampler/groebner.py
+++ b/src/calt/dataset/sagemath/utils/ideal_sampler/groebner.py
@@ -1,0 +1,119 @@
+"""Direct sampling of Gröbner bases of ideals in shape position (NeurIPS'24).
+
+Reference
+---------
+Kera, Ishihara, Kambe, Vaccon, Yokoyama, "Learning to Compute Gröbner Bases"
+(NeurIPS 2024). Original implementation: ``random_shape_gb`` in
+https://github.com/HiroshiKERA/transformer-groebner (``src/dataset/groebner.sage``).
+
+Idea
+----
+Rather than sampling a generating set ``F`` and running Buchberger to obtain a
+Gröbner basis ``G`` (the forward direction implemented elsewhere in CALT), we
+sample ``G`` directly. An ideal is in *shape position* when its reduced Gröbner
+basis w.r.t. the lex order ``x_0 > x_1 > ... > x_{n-1}`` has the form
+
+    G = [ x_0 - g_1(x_{n-1}),
+          x_1 - g_2(x_{n-1}),
+          ...
+          x_{n-2} - g_{n-1}(x_{n-1}),
+          h(x_{n-1}) ]
+
+where ``h`` is a monic univariate polynomial in the last variable and each
+``g_i`` is a univariate polynomial of degree ``< deg(h)``. Such a ``G`` is, by
+construction, a reduced Gröbner basis (each ``x_i`` is the leading term and the
+tail involves only ``x_{n-1}``), so no Gröbner computation is needed.
+"""
+
+from sage.all import PolynomialRing, matrix
+
+from ..polynomial_sampler import PolynomialSampler
+
+
+def _to_monic(p):
+    """Scale ``p`` so its leading coefficient is 1 (``p`` is over a field)."""
+    return p / p.lc()
+
+
+class GroebnerBasisSampler:
+    """Sample reduced Gröbner bases of ideals in shape position.
+
+    Args:
+        ring: SageMath multivariate ``PolynomialRing`` (the target ring). The lex
+            shape position is taken w.r.t. its variable order.
+        max_degree: Maximum degree of the univariate tail ``h``.
+        min_degree: Minimum degree of ``h`` (``>= 1``).
+        max_num_terms: Upper bound on the number of terms per univariate poly.
+        max_coeff: Coefficient bound for RR/ZZ (passed to ``PolynomialSampler``).
+        num_bound: Numerator/denominator bound for QQ.
+        degree_sampling, term_sampling: ``'uniform'`` or ``'fixed'``.
+        strictly_conditioned: Forwarded to ``PolynomialSampler``.
+    """
+
+    def __init__(
+        self,
+        ring,
+        max_degree: int = 5,
+        min_degree: int = 1,
+        max_num_terms: int | None = None,
+        max_coeff: int | None = None,
+        num_bound: int | None = None,
+        degree_sampling: str = "uniform",
+        term_sampling: str = "uniform",
+        strictly_conditioned: bool = True,
+    ):
+        self.ring = ring
+        self.max_degree = max_degree
+        self.min_degree = max(1, min_degree)
+        self.max_num_terms = max_num_terms
+        self.max_coeff = max_coeff
+        self.num_bound = num_bound
+        self.degree_sampling = degree_sampling
+        self.term_sampling = term_sampling
+        self.strictly_conditioned = strictly_conditioned
+
+    def _usampler(self, uring, max_degree, min_degree):
+        return PolynomialSampler(
+            ring=uring,
+            order=None,  # required: PolynomialSampler forbids ring + order together
+            max_degree=max_degree,
+            min_degree=min_degree,
+            max_num_terms=self.max_num_terms,
+            max_coeff=self.max_coeff,
+            num_bound=self.num_bound,
+            degree_sampling=self.degree_sampling,
+            term_sampling=self.term_sampling,
+            strictly_conditioned=self.strictly_conditioned,
+            nonzero_instance=True,
+        )
+
+    def _sample_one(self) -> list:
+        ring = self.ring
+        field = ring.base_ring()
+        x = ring.gens()
+        n = ring.ngens()
+
+        # Univariate ring in the last variable (lex), used to draw h and the g_i.
+        uring = PolynomialRing(field, names=[str(x[-1])], order="lex")
+
+        # 1) h: monic univariate of degree in [min_degree, max_degree].
+        h = self._usampler(uring, self.max_degree, self.min_degree).sample(1)[0]
+        h = _to_monic(h)
+        deg_h = int(h.degree())
+
+        # 2) g_1, ..., g_{n-1}: univariate of degree < deg(h).
+        if n > 1:
+            g_sampler = self._usampler(uring, max(0, deg_h - 1), 0)
+            tail = g_sampler.sample(num_samples=1, size=(n - 1, 1))[0]  # (n-1) x 1
+            G = tail.stack(matrix(uring, 1, 1, [h])).change_ring(ring)
+        else:
+            G = matrix(ring, 1, 1, [ring(h)])
+
+        # Add the leading variables: row i (< n-1) becomes x_i + (univariate tail).
+        X = matrix(ring, n, 1, [*x[:-1], 0])
+        G = G + X
+        return [G[i, 0] for i in range(n)]
+
+    def sample(self, num_samples: int = 1) -> list:
+        """Return ``num_samples`` Gröbner bases, each a list of ring elements."""
+        return [self._sample_one() for _ in range(num_samples)]

--- a/src/calt/dataset/sympy/dataset_generator.py
+++ b/src/calt/dataset/sympy/dataset_generator.py
@@ -70,8 +70,22 @@ def setup_logging():
                 handler.setFormatter(logging.Formatter("%(message)s"))
 
 
-def _worker_init():
+# Worker-process globals. The instance generator and statistics calculator are
+# transmitted ONCE per worker — via the joblib initializer (spawn/loky) or by
+# fork inheritance (multiprocessing on Linux) — instead of being pickled with
+# every task. Passing them per task pickles the (possibly large) generator
+# closure for each sample; see issue #37 (up to ~469x slowdown).
+_WORKER_INSTANCE_GENERATOR = None
+_WORKER_STATISTICS_CALCULATOR = None
+
+
+def _worker_init(instance_generator=None, statistics_calculator=None):
     setup_logging()
+    global _WORKER_INSTANCE_GENERATOR, _WORKER_STATISTICS_CALCULATOR
+    if instance_generator is not None:
+        _WORKER_INSTANCE_GENERATOR = instance_generator
+    if statistics_calculator is not None:
+        _WORKER_STATISTICS_CALCULATOR = statistics_calculator
 
 
 # Setup logging for this module
@@ -140,12 +154,17 @@ class DatasetGenerator:
         self,
         sample_index: int,
         tag: str,
-        instance_generator: Callable,
-        statistics_calculator: Callable | None = None,
     ) -> tuple[
         StringProblemOrAnswer, StringProblemOrAnswer, StatisticsDict | None, float
     ]:
-        """Generate a single sample using the provided instance generator."""
+        """Generate a single sample using the worker's instance generator.
+
+        The instance generator and statistics calculator are read from
+        worker-process globals set once by ``_worker_init`` (see issue #37),
+        rather than received as per-task arguments.
+        """
+        instance_generator = _WORKER_INSTANCE_GENERATOR
+        statistics_calculator = _WORKER_STATISTICS_CALCULATOR
         # Generate a unique seed for this job
         seed = self._generate_seed(sample_index, tag)
 
@@ -266,6 +285,12 @@ class DatasetGenerator:
                 )
                 self.logger.info("Starting parallel processing...")
 
+            # Make the generator/statistics calculator available without
+            # per-task pickling: set them in this process (used by the inline /
+            # n_jobs=1 path and inherited by forked workers) and transmit them
+            # once per worker through the initializer (see issue #37).
+            _worker_init(instance_generator, statistics_calculator)
+
             # Generate samples for current batch in parallel using joblib
             try:
                 results = Parallel(
@@ -273,13 +298,9 @@ class DatasetGenerator:
                     backend=self.backend,
                     verbose=self.verbose,
                     initializer=_worker_init,
+                    initargs=(instance_generator, statistics_calculator),
                 )(
-                    delayed(self._generate_sample)(
-                        batch_start + i,
-                        tag,
-                        instance_generator,
-                        statistics_calculator,
-                    )
+                    delayed(self._generate_sample)(batch_start + i, tag)
                     for i in range(current_batch_size)
                 )
             except (MemoryError, OSError) as e:

--- a/tests/dataset/test_ideal_backward_generation.py
+++ b/tests/dataset/test_ideal_backward_generation.py
@@ -1,0 +1,119 @@
+"""Tests for "backward" ideal data generation (sample basis G, transform to F).
+
+Gröbner (NeurIPS'24): shape-position GB sampler + Bruhat transform F=U·P·A·G.
+Border  (NeurIPS'25): border-basis sampler + generalized transform F=A·G.
+
+Both directions are checked for ideal invariance (``<F> = <G>``) and, for
+Gröbner, that ``G`` is exactly the reduced Gröbner basis of ``<F>``.
+"""
+
+import pytest
+
+sage = pytest.importorskip("sage.all")
+from sage.all import GF, QQ, Ideal, PolynomialRing  # noqa: E402
+
+from calt.dataset.sagemath.utils.ideal_invariant_transformer import (  # noqa: E402
+    BorderIdealTransformer,
+    GroebnerIdealTransformer,
+)
+from calt.dataset.sagemath.utils.ideal_sampler import (  # noqa: E402
+    BorderBasisSampler,
+    GroebnerBasisSampler,
+)
+
+
+def _gb(ideal):
+    """Gröbner basis via Singular's ``std`` (avoids a Hilbert-driven crash on
+    some Singular builds with the default ``groebner`` algorithm)."""
+    return list(ideal.groebner_basis(algorithm="singular:std"))
+
+
+def _monic_set(polys):
+    return {str(p / p.lc()) for p in polys}
+
+
+def _same_ideal(F, G):
+    return _monic_set(_gb(Ideal(F))) == _monic_set(_gb(Ideal(G)))
+
+
+# --------------------------------------------------------------------------- #
+# Gröbner (NeurIPS'24)                                                          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("field", [GF(7), QQ])
+def test_groebner_sampler_returns_groebner_bases(field):
+    R = PolynomialRing(field, names=("x", "y", "z"), order="lex")
+    sampler = GroebnerBasisSampler(
+        R, max_degree=3, min_degree=1, max_num_terms=4, max_coeff=3, num_bound=3
+    )
+    for G in sampler.sample(5):
+        assert len(G) == R.ngens()
+        assert Ideal(G).basis_is_groebner() is True
+
+
+@pytest.mark.parametrize("field", [GF(7), QQ])
+def test_groebner_backward_preserves_ideal_and_target(field):
+    R = PolynomialRing(field, names=("x", "y", "z"), order="lex")
+    sampler = GroebnerBasisSampler(
+        R, max_degree=3, min_degree=1, max_num_terms=4, max_coeff=3, num_bound=3
+    )
+    transformer = GroebnerIdealTransformer(
+        R,
+        max_size=6,
+        max_degree=1,
+        min_degree=0,
+        max_num_terms=3,
+        max_coeff=3,
+        num_bound=3,
+        coeff_bound=10**6,
+    )
+    for G in sampler.sample(5):
+        F = transformer.transform(G)
+        assert R.ngens() <= len(F) <= 6
+        gF = _gb(Ideal(F))
+        # <F> = <G>, and G is exactly the reduced Gröbner basis of <F>.
+        assert all(f.reduce(G) == 0 for f in F)  # <F> ⊆ <G>
+        assert all(g.reduce(gF) == 0 for g in G)  # <G> ⊆ <F>
+        assert _monic_set(gF) == _monic_set(G)
+
+
+# --------------------------------------------------------------------------- #
+# Border (NeurIPS'25)                                                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("field", [GF(7), QQ])
+def test_border_sampler_returns_zero_dimensional_bases(field):
+    R = PolynomialRing(field, names=("x", "y"), order="degrevlex")
+    sampler = BorderBasisSampler(R)
+    Gs = sampler.sample(4, degree_bounds=[3, 3], total_degree_bound=4)
+    assert len(Gs) == 4
+    for G in Gs:
+        assert len(G) >= 1
+        assert Ideal(G).dimension() == 0  # border bases are 0-dimensional
+
+
+@pytest.mark.parametrize("field", [GF(7), QQ])
+def test_border_backward_preserves_ideal(field):
+    """Faithful reference transform (random A) with constant (degree-0) entries
+    is exactly ideal-invariant: F is a set of field-linear combinations of G."""
+    R = PolynomialRing(field, names=("x", "y"), order="degrevlex")
+    sampler = BorderBasisSampler(R)
+    transformer = BorderIdealTransformer(
+        R, max_size=6, max_degree=0, min_degree=0, max_coeff=3, num_bound=3
+    )
+    for G in sampler.sample(4, degree_bounds=[3, 3], total_degree_bound=4):
+        F = transformer.transform(G)
+        assert len(F) > len(G)
+        assert _same_ideal(F, G)
+
+
+def test_border_transform_identity_block_is_exact():
+    """identity_block=True makes <F>=<G> exact for any entry degree (F contains G)."""
+    R = PolynomialRing(GF(7), names=("x", "y"), order="degrevlex")
+    G = BorderBasisSampler(R).sample(1, degree_bounds=[3, 3], total_degree_bound=4)[0]
+    F = BorderIdealTransformer(
+        R, max_size=5, identity_block=True, max_degree=2
+    ).transform(G)
+    assert all(g in F for g in G)  # the identity block keeps G verbatim in F


### PR DESCRIPTION
Two related changes to the dataset layer:

1. Backward ideal data generation (paper algorithms). Sample a basis G directly and transform it into a generating set F (instead of sampling F and computing G). Under calt/dataset/sagemath/utils/:

ideal_sampler/: GroebnerBasisSampler (Gröbner bases in shape position, NeurIPS'24 random_shape_gb), BorderBasisSampler (border bases, NeurIPS'25).
ideal_invariant_transformer/: GroebnerIdealTransformer (F=U·P·A·G, Bruhat, NeurIPS'24 random_non_gb), BorderIdealTransformer (F=A·G, NeurIPS'25 backward_basis_transformation).
Tests verify ideal invariance <F>=<G> over GF(7) and QQ, and that sampled Gröbner sets are the reduced GB of <F>.

2. Fixes #37 — slow DatasetGenerator. The instance_generator was pickled per task (joblib delayed); it is now transmitted once per worker via initializer/initargs. A/B on the issue's repro: 4.3s → 0.3s (exact issue script: 50.6s → 0.08s). Output byte-identical. Applied to both the SageMath and SymPy generators.