### PR TITLE
Fix reproduction bugs in ISSAC 2026 experiments

### DIFF
--- a/issac2026_experiments/polynomial_reduction/generate_dataset.py
+++ b/issac2026_experiments/polynomial_reduction/generate_dataset.py
@@ -41,7 +41,7 @@ class UnivariateQuoRemGenerator:
 
         q, r = f.quo_rem(g)
 
-        return (f, g), (q, r)
+        return [f, g], [q, r]
 
 
 @click.command()

--- a/issac2026_experiments/relu_recurrence/generate_dataset.py
+++ b/issac2026_experiments/relu_recurrence/generate_dataset.py
@@ -32,7 +32,7 @@ class ReLURecurrenceGenerator:
 
     def __call__(self, seed: int) -> tuple[str, str]:
         set_random_seed(seed)
-        x_list = [randint(self.x_min, self.x_max + 1) for _ in range(self.length)]
+        x_list = [randint(self.x_min, self.x_max) for _ in range(self.length)]
         y_list = [float(x_list[0])]
         for i in range(1, self.length):
             y_list.append(relu(x_list[i] + y_list[i - 1]))

--- a/src/calt/io/preprocessor/load_preprocessors/expanded_form.py
+++ b/src/calt/io/preprocessor/load_preprocessors/expanded_form.py
@@ -21,7 +21,11 @@ def _poly_terms(poly: Any) -> list[tuple[tuple[int, ...], Any]]:
         pass
     # SageMath polynomial: .dict() -> {exponent_tuple: coefficient}
     if hasattr(poly, "dict"):
-        return [(exp, c) for exp, c in poly.dict().items() if c != 0]
+        return [
+            (exp if isinstance(exp, tuple) else (int(exp),), c)
+            for exp, c in poly.dict().items()
+            if c != 0
+        ]
     raise TypeError(
         f"Expected SymPy PolyElement or SageMath polynomial, got {type(poly).__name__}"
     )

--- a/tests/train/test_generation_evaluation.py
+++ b/tests/train/test_generation_evaluation.py
@@ -69,4 +69,3 @@ def test_generate_stops_per_sequence_after_eos():
         [config.bos_token_id, config.eos_token_id, config.pad_token_id],
         [config.bos_token_id, 5, config.eos_token_id],
     ]
-

--- a/tests/train/test_generation_evaluation.py
+++ b/tests/train/test_generation_evaluation.py
@@ -1,0 +1,72 @@
+"""Tests for generation evaluation and stop behavior."""
+
+import torch
+import torch.nn as nn
+
+from calt.models.generic.model import Transformer, TransformerConfig
+
+
+class PlannedLMHead(nn.Module):
+    """LM head that emits predefined next-token plans per decoding step."""
+
+    def __init__(self, token_plan: list[list[int]], vocab_size: int):
+        super().__init__()
+        self.token_plan = token_plan
+        self.vocab_size = vocab_size
+        self.step = 0
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size = hidden_states.shape[0]
+        logits = torch.full(
+            (batch_size, self.vocab_size),
+            -1e9,
+            device=hidden_states.device,
+        )
+        plan_idx = min(self.step, len(self.token_plan) - 1)
+        step_plan = self.token_plan[plan_idx]
+        for idx, token_id in enumerate(step_plan):
+            logits[idx, token_id] = 0.0
+        self.step += 1
+        return logits
+
+
+def test_generate_stops_per_sequence_after_eos():
+    """Once a sequence emits EOS, subsequent tokens must be PAD for that row."""
+    config = TransformerConfig(
+        d_model=8,
+        attention_heads=2,
+        num_encoder_layers=1,
+        num_decoder_layers=1,
+        dim_feedforward=16,
+        dropout=0.0,
+        vocab_size=20,
+        max_input_len=16,
+        pad_token_id=0,
+        eos_token_id=1,
+        bos_token_id=2,
+        use_positional_embedding="generic",
+    )
+    model = Transformer(config)
+    model.eval()
+    model.lm_head = PlannedLMHead(
+        token_plan=[
+            [1, 5],  # step 1: row0 finishes, row1 continues
+            [7, 1],  # step 2: row0 would emit 7 without masking, row1 finishes
+        ],
+        vocab_size=config.vocab_size,
+    )
+
+    input_ids = torch.tensor([[3, 4, 5], [6, 7, 8]], dtype=torch.long)
+    attention_mask = torch.ones_like(input_ids)
+
+    generated = model.generate(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        max_length=4,
+    )
+
+    assert generated.tolist() == [
+        [config.bos_token_id, config.eos_token_id, config.pad_token_id],
+        [config.bos_token_id, 5, config.eos_token_id],
+    ]
+


### PR DESCRIPTION
Bug fixes found while reproducing the §5 benchmarks from the paper.

- Batched generation / EOS (cherry-pick of daf57f4): finished sequences kept emitting tokens past EOS, corrupting exact-match under batched decoding. Added a finished mask (PAD after EOS).
- io/expanded_form.py: univariate SageMath poly.dict() returns a scalar exponent instead of a tuple, crashing E{e} token construction. Normalize to a 1-tuple.
- polynomial_reduction/generate_dataset.py: generator returned tuples (f, g), serialized as "(f, g)" instead of "f | g". Return lists.
- relu_recurrence/generate_dataset.py: Sage's randint is inclusive, so x_max + 1 sampled from {x_min..x_max+1}. Fixed the bound (dataset must be regenerated).

Note: fix #2 is a library bug (src/calt/) and likely warrants a separate PR to main.