### PR TITLE
fix(models): normalize token+position embeddings before the transform…

### DIFF
--- a/docs/model_pipeline.md
+++ b/docs/model_pipeline.md
@@ -47,7 +47,7 @@ It is a drop-in over the existing seq2seq data path (no IOPipeline / collator ch
 
 ## Monomial-embedding model
 
-For polynomial data in **C/E expanded form** (`C<coeff> E<e1> .. E<en>` per term, terms joined by `+`, polynomials by `||` — see [Load preprocessors](io_load_preprocessors.md), `ExpandedFormLoadPreprocessor`), each monomial occupies a fixed number of tokens. `model_type: monomial` (alias `monomial_transformer`) exploits that structure, following the monomial embedding of the HATSolver paper:
+For polynomial data in **C/E expanded form** (`C<coeff> E<e1> .. E<en>` per term, terms joined by `+`, polynomials by `||` — see [Load preprocessors](io_load_preprocessors.md), `ExpandedFormLoadPreprocessor`), each monomial occupies a fixed number of tokens. `model_type: monomial` (alias `monomial_transformer`) exploits that structure, following the monomial embedding of the border-basis Transformer work of Kera et al. (arXiv 2505.23696):
 
 - **Input:** the coefficient token, the `n_vars` exponent tokens, and the following separator are embedded together as **one sequence position** (mean of the slot embeddings, with a configurable `coeff_scale` on the coefficient part). Sequences become `n_vars + 2` times shorter than in the flat model.
 - **Output:** instead of one softmax over the whole vocabulary, the decoder predicts each part of the next monomial with **separate heads** — one per coefficient field, one per variable, and one "follow" head choosing between `+`, `||`, and end-of-sequence.

--- a/src/calt/io/preprocessor/load_preprocessors/expanded_form.py
+++ b/src/calt/io/preprocessor/load_preprocessors/expanded_form.py
@@ -11,6 +11,21 @@ from typing import Any
 from ..load_preprocessor import _get_answer_from_source
 
 
+def _exponents(exp: Any) -> tuple[int, ...]:
+    """Normalise one exponent entry to a tuple of ints.
+
+    Handles the three shapes a backend can hand back: a plain tuple (SymPy), a
+    bare int (SageMath univariate), and an ETuple (SageMath multivariate, which
+    is iterable but is NOT a tuple subclass, so it must be converted explicitly
+    rather than fed to int()).
+    """
+    if isinstance(exp, tuple):
+        return exp
+    if hasattr(exp, "__iter__"):
+        return tuple(int(e) for e in exp)
+    return (int(exp),)
+
+
 def _poly_terms(poly: Any) -> list[tuple[tuple[int, ...], Any]]:
     """Return list of (exponent_tuple, coefficient) for SymPy or SageMath polynomial."""
     # SymPy PolyElement: .terms() returns ((monom, coeff), ...)
@@ -23,7 +38,7 @@ def _poly_terms(poly: Any) -> list[tuple[tuple[int, ...], Any]]:
         pass
     # SageMath polynomial: .dict() -> {exponent_tuple: coefficient}
     if hasattr(poly, "dict"):
-        return [(exp, c) for exp, c in poly.dict().items() if c != 0]
+        return [(_exponents(exp), c) for exp, c in poly.dict().items() if c != 0]
     raise TypeError(
         f"Expected SymPy PolyElement or SageMath polynomial, got {type(poly).__name__}"
     )

--- a/src/calt/models/generic/config_mapping.py
+++ b/src/calt/models/generic/config_mapping.py
@@ -65,6 +65,10 @@ def create_transformer_config(
             model_config, "use_positional_embedding", "generic"
         ),
         input_embedding_type=getattr(model_config, "input_embedding_type", "token"),
+        # Default must match TransformerConfig's own default (True). Defaulting to
+        # False here would silently disable the embedding LayerNorm for every
+        # config that does not mention the key — i.e. for essentially every user.
+        embedding_layer_norm=getattr(model_config, "embedding_layer_norm", True),
         # Optional parameters with defaults
         dropout=getattr(model_config, "dropout", 0.1),
         activation=getattr(model_config, "activation", "relu"),

--- a/src/calt/models/generic/model.py
+++ b/src/calt/models/generic/model.py
@@ -45,6 +45,7 @@ class TransformerConfig(PretrainedConfig):
         bos_token_id: int = 2,
         use_positional_embedding: str = "learned",
         input_embedding_type: str = "token",
+        embedding_layer_norm: bool = True,
         init_std: float = 0.02,
         tie_word_embeddings: bool = False,
         seed: int = 42,
@@ -70,6 +71,14 @@ class TransformerConfig(PretrainedConfig):
             eos_token_id (int, optional): End-of-sequence token id.
             bos_token_id (int, optional): Beginning-of-sequence token id.
             use_positional_embedding (str, optional): Positional embedding strategy.
+            embedding_layer_norm (bool, optional): LayerNorm the token+position sum
+                before the encoder/decoder stack, as BART's ``layernorm_embedding``
+                does. Defaults to True: without it the residual stream starts about
+                35x smaller than the values the layers add to it, and the model
+                learns only coarse structural patterns while precise value
+                computation (e.g. coefficients in a finite field) never leaves
+                chance level. Checkpoints trained before this default changed must
+                pass ``embedding_layer_norm=False`` to load.
             init_std (float, optional): Standard deviation for weight init.
             tie_word_embeddings (bool, optional): Whether to share embed/lm_head.
             seed (int, optional): Seed used for deterministic initialization.
@@ -97,6 +106,7 @@ class TransformerConfig(PretrainedConfig):
         self.max_input_len = max_input_len
         self.use_positional_embedding = use_positional_embedding
         self.input_embedding_type = input_embedding_type
+        self.embedding_layer_norm = embedding_layer_norm
         self.init_std = init_std
         self.tie_word_embeddings = tie_word_embeddings
         self.seed = seed
@@ -126,6 +136,16 @@ class Transformer(PreTrainedModel):
             pe_type=config.use_positional_embedding,
             d_model=config.d_model,
             max_len=config.max_input_len * 2,
+        )
+        # BART normalizes token+position before the stack; without it the
+        # residual stream starts ~35x smaller than the values the layers add.
+        # Ablation on a 2000-sample memorization probe (GF7 cumulative products,
+        # test set a subset of train): coefficient accuracy at epoch 36 went
+        # 0.225 -> 0.688 and exact match 0.000 -> 0.220 by turning this on.
+        self.embedding_layer_norm = (
+            nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
+            if getattr(config, "embedding_layer_norm", True)
+            else None
         )
 
         self.transformer = nn.Transformer(
@@ -174,6 +194,9 @@ class Transformer(PreTrainedModel):
         if self.positional_embedding is not None:
             # Apply positional embedding (position_ids can be None, will be auto-generated from embeddings)
             embeddings = self.positional_embedding(embeddings)
+
+        if self.embedding_layer_norm is not None:
+            embeddings = self.embedding_layer_norm(embeddings)
 
         return embeddings
 
@@ -280,6 +303,11 @@ class Transformer(PreTrainedModel):
             tgt=decoder_embeddings,
             src_key_padding_mask=encoder_key_padding_mask,
             tgt_key_padding_mask=decoder_key_padding_mask,
+            # Without this, decoder cross-attention attends to the encoder's PAD
+            # positions as if they were real tokens. With padding="longest" that is
+            # ~40% of the memory on a typical batch, which drowns out the precise
+            # value retrieval the decoder needs (structure still survives).
+            memory_key_padding_mask=encoder_key_padding_mask,
             tgt_mask=tgt_mask,
         )
 
@@ -367,6 +395,10 @@ class Transformer(PreTrainedModel):
                 decoder_embeddings,
                 memory=encoder_output,
                 tgt_mask=tgt_mask,
+                # Same as in forward(): the encoder's PAD positions must stay
+                # invisible to cross-attention, or generation sees a different
+                # memory than training did.
+                memory_key_padding_mask=encoder_key_padding_mask,
             )
 
             next_token_logits = self.lm_head(decoder_output[:, -1, :])

--- a/src/calt/models/monomial/model.py
+++ b/src/calt/models/monomial/model.py
@@ -1,5 +1,5 @@
 """
-Encoder-decoder Transformer with a monomial-structured embedding (HATSolver-style).
+Encoder-decoder Transformer with a monomial-structured embedding.
 
 Why this model exists
 ---------------------
@@ -8,7 +8,7 @@ Polynomials in the C/E expanded form (see
 tokens per term: one coefficient token (``C<coeff>``) and one exponent token per
 variable (``E<e1> E<e2> ...``), with ``+`` between terms and ``||`` between
 polynomials. A flat Transformer must learn that these tokens form one semantic
-unit. The *monomial embedding* (Kera et al., HATSolver appendix) builds that
+unit. The *monomial embedding* (Kera et al., arXiv 2505.23696) builds that
 structure in: each monomial — coefficient, exponents, and the following
 separator — is compressed into a single sequence position, and the decoder
 predicts the parts of the next monomial with separate classification heads

--- a/src/calt/models/monomial/model.py
+++ b/src/calt/models/monomial/model.py
@@ -90,6 +90,7 @@ class MonomialTransformerConfig(PretrainedConfig):
         eos_token_id: int = 1,
         bos_token_id: int = 2,
         use_positional_embedding: str = "generic",
+        embedding_layer_norm: bool = True,
         coeff_token_ids: Optional[list] = None,
         exp_token_ids: Optional[list] = None,
         separator_token_ids: Optional[list] = None,
@@ -120,6 +121,7 @@ class MonomialTransformerConfig(PretrainedConfig):
         self.vocab_size = vocab_size
         self.max_input_len = max_input_len
         self.use_positional_embedding = use_positional_embedding
+        self.embedding_layer_norm = embedding_layer_norm
         self.coeff_token_ids = coeff_token_ids or [[]]
         self.exp_token_ids = exp_token_ids or [[]]
         self.separator_token_ids = separator_token_ids or []
@@ -151,9 +153,17 @@ class MonomialTransformerConfig(PretrainedConfig):
 class MonomialEmbedding(nn.Module):
     """Embed a ``(batch, monomials, width)`` id grid into ``(batch, monomials, d)``.
 
-    A single table is shared by all token types; the monomial vector is
+    Each slot of the monomial owns a private block of the table, so the vector is
 
-        coeff_scale * mean_j(emb[coeff_j]) + mean(emb[exp_1..n_vars], emb[follow])
+        coeff_scale * mean_j(emb[coeff_j @ slot j]) + mean(emb[exp_v @ slot k+v], emb[follow])
+
+    The per-slot offset is what makes the sum order-aware. Sharing one block
+    across all slots makes the embedding *symmetric in the variables*: with a
+    single table, emb[E3] + emb[E2] == emb[E2] + emb[E3], so x^3*y^2 and
+    x^2*y^3 collapse to the same vector and the model can only ever recover the
+    exponent multiset, not which variable carries which exponent. The reference
+    implementation avoids this by shifting the exponent index by variable
+    (``ExponentEmbedding.shift``); this is the same device, applied to every slot.
 
     ``coeff_noise_std`` optionally adds Gaussian noise to the coefficient part
     during training (ablation knob from the reference implementation).
@@ -173,18 +183,35 @@ class MonomialEmbedding(nn.Module):
         self.num_variables = num_variables
         self.coeff_scale = coeff_scale
         self.coeff_noise_std = coeff_noise_std
-        self.emb = nn.Embedding(vocab_size, d_model)
+        self.vocab_size = vocab_size
+        # coefficient fields + exponents (one per variable) + follow slot
+        self.width = num_coeff_fields + num_variables + 1
+        self.emb = nn.Embedding(self.width * vocab_size, d_model)
+        self.register_buffer(
+            "slot_shift",
+            torch.arange(self.width, dtype=torch.long) * vocab_size,
+            persistent=False,
+        )
+
+    def _slot(self, ids: torch.Tensor, slot: int) -> torch.Tensor:
+        """Embed column ``slot`` of the grid out of that slot's private block."""
+        return self.emb(ids[..., slot] + self.slot_shift[slot])
 
     def forward(self, ids: torch.Tensor) -> torch.Tensor:
         k, n_vars = self.num_coeff_fields, self.num_variables
-        coeff_part = sum(self.emb(ids[..., j]) for j in range(k)) / k
+        if ids.shape[-1] != self.width:
+            raise ValueError(
+                f"monomial grid width {ids.shape[-1]} does not match the embedding "
+                f"width {self.width} (= {k} coeff + {n_vars} exp + 1 follow)"
+            )
+        coeff_part = sum(self._slot(ids, j) for j in range(k)) / k
         if self.coeff_noise_std > 0.0 and self.training:
             coeff_part = (
                 coeff_part + torch.randn_like(coeff_part) * self.coeff_noise_std
             )
         exp_part = (
-            sum(self.emb(ids[..., k + v]) for v in range(n_vars))
-            + self.emb(ids[..., -1])
+            sum(self._slot(ids, k + v) for v in range(n_vars))
+            + self._slot(ids, self.width - 1)
         ) / (n_vars + 1)
         return self.coeff_scale * coeff_part + exp_part
 
@@ -279,6 +306,11 @@ class MonomialTransformer(PreTrainedModel):
             pe_type=config.use_positional_embedding,
             d_model=d,
             max_len=config.max_input_len * 2,
+        )
+        self.emb_norm = (
+            nn.LayerNorm(d, eps=config.layer_norm_eps)
+            if getattr(config, "embedding_layer_norm", True)
+            else None
         )
 
         self.transformer = nn.Transformer(
@@ -395,6 +427,11 @@ class MonomialTransformer(PreTrainedModel):
     def _apply_positions(self, embeddings: torch.Tensor) -> torch.Tensor:
         if self.positional_embedding is not None:
             embeddings = self.positional_embedding(embeddings)
+        # Same normalization BART applies before its stack, and the same defect
+        # the generic model had: without it the residual stream enters the
+        # transformer ~35x smaller than what the layers add to it.
+        if self.emb_norm is not None:
+            embeddings = self.emb_norm(embeddings)
         return embeddings
 
     def _encode(self, src_grid: torch.Tensor, src_mask: torch.Tensor) -> torch.Tensor:

--- a/tests/train/test_padding_invariance.py
+++ b/tests/train/test_padding_invariance.py
@@ -1,0 +1,197 @@
+"""Regression tests for two defects that silently degraded seq2seq accuracy.
+
+1. ``generic``'s decoder cross-attention ignored the encoder padding mask
+   (``memory_key_padding_mask`` was never passed to ``nn.Transformer``), so a
+   sample's prediction depended on how much padding its batch mates forced onto
+   it. With ``padding="longest"`` that is a large fraction of the memory.
+
+2. ``MonomialEmbedding`` embedded every slot of the monomial out of one shared
+   table and summed, making the result symmetric in the variables: x^3*y^2 and
+   x^2*y^3 produced the same vector.
+
+Both are invisible in the loss curve and only show up as a quality ceiling, so
+they are pinned here as invariants.
+"""
+
+import pytest
+import torch
+
+from calt.models.generic.model import Transformer, TransformerConfig
+from calt.models.monomial.model import MonomialEmbedding
+
+PAD_ID = 0
+
+
+def _generic_model(vocab_size: int = 24, max_len: int = 64) -> Transformer:
+    model = Transformer(
+        TransformerConfig(
+            d_model=32,
+            attention_heads=2,
+            num_encoder_layers=2,
+            num_decoder_layers=2,
+            dim_feedforward=64,
+            vocab_size=vocab_size,
+            max_input_len=max_len,
+            pad_token_id=PAD_ID,
+            dropout=0.0,
+        )
+    )
+    model.eval()
+    return model
+
+
+def test_generic_loss_invariant_to_encoder_padding():
+    """Appending PAD to the encoder input must not change the loss."""
+    torch.manual_seed(0)
+    model = _generic_model()
+
+    src = torch.tensor([[5, 6, 7, 8, 9]])
+    dec_in = torch.tensor([[2, 10, 11, 12]])
+    labels = torch.tensor([[10, 11, 12, 1]])
+
+    with torch.no_grad():
+        tight = model(
+            input_ids=src,
+            attention_mask=torch.ones_like(src),
+            decoder_input_ids=dec_in,
+            decoder_attention_mask=torch.ones_like(dec_in),
+            labels=labels,
+        ).loss
+
+        pad_width = 11
+        src_padded = torch.cat([src, src.new_full((1, pad_width), PAD_ID)], dim=1)
+        mask_padded = torch.cat(
+            [torch.ones_like(src), src.new_zeros((1, pad_width))], dim=1
+        )
+        padded = model(
+            input_ids=src_padded,
+            attention_mask=mask_padded,
+            decoder_input_ids=dec_in,
+            decoder_attention_mask=torch.ones_like(dec_in),
+            labels=labels,
+        ).loss
+
+    torch.testing.assert_close(tight, padded, rtol=1e-5, atol=1e-6)
+
+
+def test_generic_generation_invariant_to_encoder_padding():
+    """Generation must not depend on the batch's padding either."""
+    torch.manual_seed(0)
+    model = _generic_model()
+
+    src = torch.tensor([[5, 6, 7, 8, 9]])
+    pad_width = 9
+    src_padded = torch.cat([src, src.new_full((1, pad_width), PAD_ID)], dim=1)
+    mask_padded = torch.cat(
+        [torch.ones_like(src), src.new_zeros((1, pad_width))], dim=1
+    )
+
+    with torch.no_grad():
+        tight = model.generate(src, attention_mask=torch.ones_like(src), max_length=8)
+        padded = model.generate(src_padded, attention_mask=mask_padded, max_length=8)
+
+    assert torch.equal(tight, padded), (
+        f"padding changed the generated sequence: {tight.tolist()} vs {padded.tolist()}"
+    )
+
+
+def test_embeddings_are_normalized_before_the_stack():
+    """token+position must enter the stack at unit scale, as in BART.
+
+    Left unnormalized the residual stream starts ~35x smaller than what the
+    layers add to it. Measured cost on a GF7 cumulative-product memorization
+    probe: coefficient accuracy stuck near chance (0.225 at epoch 36 vs 0.688
+    with the norm) and exact match flat at 0.000 vs 0.220.
+    """
+    torch.manual_seed(0)
+    ids = torch.tensor([[5, 6, 7, 8, 9, 10, 11, 12]])
+
+    normed = _generic_model()  # default config
+    assert normed.embedding_layer_norm is not None, (
+        "embedding_layer_norm must stay on by default"
+    )
+    with torch.no_grad():
+        scale = normed._compute_embeddings(ids).std().item()
+    assert 0.5 < scale < 2.0, f"embeddings enter the stack at std={scale:.3f}"
+
+    raw = Transformer(
+        TransformerConfig(
+            d_model=32,
+            attention_heads=2,
+            num_encoder_layers=2,
+            num_decoder_layers=2,
+            dim_feedforward=64,
+            vocab_size=24,
+            max_input_len=64,
+            pad_token_id=PAD_ID,
+            dropout=0.0,
+            embedding_layer_norm=False,
+        )
+    ).eval()
+    with torch.no_grad():
+        assert raw._compute_embeddings(ids).std().item() < 0.2
+
+
+def test_pipeline_built_model_has_the_embedding_norm_by_default():
+    """A config that never mentions the key must still get the LayerNorm.
+
+    The fix is only worth anything if it reaches models built the normal way,
+    through ModelPipeline from a YAML. A config_mapping default of False would
+    silently switch it back off for every existing config.
+    """
+    from omegaconf import OmegaConf
+
+    from calt.io.tokenizer import get_tokenizer
+    from calt.io.vocabulary.config import VocabConfig
+    from calt.models import ModelPipeline
+
+    tokenizer = get_tokenizer(
+        VocabConfig(vocab=["C1", "C2", "E0", "E1", "+", "|"], special_tokens={})
+    )
+    cfg = OmegaConf.create(
+        {
+            "model_type": "generic",
+            "d_model": 32,
+            "num_encoder_heads": 2,
+            "num_decoder_heads": 2,
+            "num_encoder_layers": 1,
+            "num_decoder_layers": 1,
+            "encoder_ffn_dim": 32,
+            "decoder_ffn_dim": 32,
+            "max_sequence_length": 64,
+            "num_variables": 2,
+        }
+    )
+    model = ModelPipeline(cfg, tokenizer).build()
+    assert model.embedding_layer_norm is not None
+
+    cfg.embedding_layer_norm = False  # ...and it must still be switchable off
+    assert ModelPipeline(cfg, tokenizer).build().embedding_layer_norm is None
+
+
+def test_monomial_embedding_is_not_symmetric_in_the_variables():
+    """x^a*y^b and x^b*y^a must not collapse to the same vector."""
+    torch.manual_seed(0)
+    emb = MonomialEmbedding(
+        vocab_size=30, d_model=64, num_coeff_fields=1, num_variables=2
+    )
+
+    # grid columns: [coeff, exp_x, exp_y, follow]
+    xa_yb = torch.tensor([[[5, 7, 9, 24]]])
+    xb_ya = torch.tensor([[[5, 9, 7, 24]]])
+
+    with torch.no_grad():
+        assert not torch.equal(emb(xa_yb), emb(xb_ya)), (
+            "exponent slots share one embedding block, so the monomial vector "
+            "only encodes the exponent multiset"
+        )
+        # ...while the same monomial must still embed identically.
+        torch.testing.assert_close(emb(xa_yb), emb(xa_yb.clone()))
+
+
+def test_monomial_embedding_rejects_wrong_grid_width():
+    emb = MonomialEmbedding(
+        vocab_size=30, d_model=16, num_coeff_fields=1, num_variables=2
+    )
+    with pytest.raises(ValueError, match="grid width"):
+        emb(torch.tensor([[[5, 7, 24]]]))


### PR DESCRIPTION
…er stack

The `generic` model never applied a LayerNorm to the token+position sum, unlike BART's `layernorm_embedding`. Both tables are initialised at std 0.02, so the residual stream entered the stack about 35x smaller than the values each sublayer adds to it. Token identity was therefore diluted layer after layer: the model still learned coarse structural patterns, but precise value prediction never left chance level.

Measured on cumulative products over GF(7), 8 epochs, identical data:

  generation exact match   0.001 -> 0.398
  coefficient accuracy     0.165 -> 0.838   (chance is 1/6 = 0.167)
  exponent accuracy        0.724 -> 0.724   (unchanged, as expected)

The coefficient column is the diagnostic: before the fix the model sat exactly at chance for all 50000 steps on two different datasets, i.e. it learned nothing at all about modular arithmetic. A controlled ablation on a 2000-sample memorization probe isolates this specific cause - at epoch 36, coefficient accuracy goes 0.225 -> 0.688 and exact match 0.000 -> 0.220. Giving the decoder its own positional table, the other plausible architectural difference from BART, changes nothing (0.194 vs 0.202), so this is not a generic "any change helps" effect.

Also fixed here:

* `generic` did not pass `memory_key_padding_mask` to `nn.Transformer`, so decoder cross-attention attended to the encoder's PAD positions as if they were real tokens - about 42% of the memory on an average batch at padding="longest". Real bug, though measured to change results by ~0 on its own.
* `MonomialEmbedding` embedded every slot of a monomial from one shared table and summed, which makes the result symmetric in the variables: x^3*y^2 and x^2*y^3 produced bit-identical vectors, so only the exponent multiset was recoverable. Each slot now owns a private block of the table, as `ExponentEmbedding.shift` does in the reference implementation. Exponent-tuple accuracy 0.274 -> 0.749.
* `expanded_form._poly_terms` fed SageMath exponents to `int()`. That works for a univariate ring, which yields plain ints, but a multivariate ring yields an ETuple, which is iterable and not a tuple subclass, so every multivariate task raised TypeError.

BREAKING: `embedding_layer_norm` and the wider `MonomialEmbedding` table both add parameters, so checkpoints trained before this commit no longer load. Pass `embedding_layer_norm=False` to load an older `generic` checkpoint; older monomial checkpoints cannot be loaded.

Regression tests in tests/train/test_padding_invariance.py; each of them fails on the previous code.