### PR TITLE
Add decoder-only model (model_type=decoder_only)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,7 +142,7 @@ train:
 ??? "`model` — Passed to ModelPipeline.from_io_dict"
     | Name | Description |
     |--------|-------------|
-    | `model_type` | Model architecture: `generic`, `bart`, or `encoder_classifier` (encoder-only single-token classification; alias `encoder_only`). See [Model pipeline](model_pipeline.md). |
+    | `model_type` | Model architecture: `generic`, `bart`, `encoder_classifier` (encoder-only single-token classification; alias `encoder_only`), `monomial`, or `decoder_only` (causal, one stack; alias `decoder`). See [Model pipeline](model_pipeline.md). |
     | `num_encoder_layers`, `num_encoder_heads` | Encoder depth and attention heads. |
     | `num_decoder_layers`, `num_decoder_heads` | Decoder depth and attention heads (ignored by `encoder_classifier`). |
     | `d_model` | Hidden size (embedding dimension). |

--- a/docs/model_pipeline.md
+++ b/docs/model_pipeline.md
@@ -25,6 +25,7 @@ Models are created via an internal `ModelRegistry`. The following types are regi
 | `bart` | HuggingFace BART for conditional generation. |
 | `encoder_classifier`, `encoder_only` | Encoder-only single-token classification model (see below). |
 | `monomial`, `monomial_transformer` | Encoder–decoder with monomial-structured embedding for C/E expanded-form data (see below). |
+| `decoder_only`, `decoder` | Decoder-only causal Transformer over `[problem, solution]` (see below). |
 
 Set `model_type` in the `model` block of `train.yaml` (e.g. `model_type: generic`). Other keys in the `model` block (e.g. `num_encoder_layers`, `d_model`, `max_sequence_length`) are documented under [Configuration — `model`](configuration.md#trainyaml--model-and-training-modelpipeline-trainerpipeline).
 
@@ -70,6 +71,34 @@ model:
 ```
 
 It is a drop-in over the existing seq2seq data path (no IOPipeline / collator change): `forward()` folds the standard flat `input_ids` / `labels` batch into a `(batch, monomials, width)` grid internally, and `generate()` returns flat token ids (`[BOS, C.., E.., +, ..., EOS]`), so decoding, metrics, and the exact-match generation evaluation work unchanged. The coefficient/exponent/separator token groups are derived from the tokenizer's vocabulary (`C<int>` — or `C<int>_<label>` for multi-field vocabularies — and `E<int>` tokens); `num_variables` is required because shared `E<k>` tokens carry no variable identity. If the data is not monomial-aligned (wrong `num_variables`, or data not in expanded form), the model raises a `ValueError` up front instead of training on a corrupted view.
+
+## Decoder-only model
+
+The arithmetic-reasoning literature generally trains decoder-only models rather than encoder–decoders. `model_type: decoder_only` (alias `decoder`) is the generic model with the encoder removed: a single causal self-attention stack running over the concatenation of the problem and its solution.
+
+The one subtlety is where prediction starts. The problem is written into the sequence as context and carries **no loss** — next-token prediction begins at the first solution token, since a model asked to reproduce the problem from `<bos>` alone could not:
+
+```
+ids     <bos> 1 3 + 0 8 <eos> <bos> 2 1 <eos>
+        |------- problem -------|--- solution ---|
+loss                                 ^^^^^^^^^^^^
+```
+
+A decoder-only model has one stack, so it takes `num_layers`, `num_heads` and `ffn_dim`. The decoder-side keys of a seq2seq block are read as a fallback, which lets an existing config run by changing `model_type` alone — at half the depth of its 6+6 counterpart.
+
+```yaml
+model:
+  model_type: decoder_only   # alias: decoder
+  num_layers: 6
+  num_heads: 8
+  d_model: 512
+  ffn_dim: 2048
+  max_sequence_length: 256
+```
+
+Like the monomial model, it is a drop-in over the existing seq2seq data path: it consumes the standard collated batch (`input_ids` / `attention_mask` / `decoder_input_ids` / `labels`), packs the two halves per example so the independent padding of the two sides never lands between them, and returns predictions and generations aligned with `labels`. `generate()` returns the completion only, not the prompt, so exact-match evaluation compares it against the labels unchanged. The `<bos>` that opens `decoder_input_ids` doubles as the marker for where the answer begins.
+
+Note that the problem and the solution now share one sequence: `max_sequence_length` has to cover both, since the positional table is sized from it.
 
 ## Custom embeddings (input and positional)
 

--- a/src/calt/models/__init__.py
+++ b/src/calt/models/__init__.py
@@ -1,4 +1,5 @@
 from .base import ModelRegistry, get_model, get_model_from_config
+from .decoder_only.model import DecoderOnlyConfig, DecoderOnlyTransformer
 from .generic.model import Transformer, TransformerConfig
 from .input_embeddings import get_input_embedding, register_input_embedding
 from .loader import ModelLoader
@@ -28,6 +29,8 @@ __all__ = [
     "TransformerConfig",
     "MonomialTransformer",
     "MonomialTransformerConfig",
+    "DecoderOnlyTransformer",
+    "DecoderOnlyConfig",
     # Pluggable embeddings (custom input + positional)
     "get_input_embedding",
     "register_input_embedding",

--- a/src/calt/models/base.py
+++ b/src/calt/models/base.py
@@ -44,6 +44,8 @@ class ModelRegistry:
         from transformers import BartConfig, BartForConditionalGeneration
 
         from .bart.config_mapping import create_bart_config
+        from .decoder_only.config_mapping import create_decoder_only_config
+        from .decoder_only.model import DecoderOnlyConfig, DecoderOnlyTransformer
         from .encoder_classifier.config_mapping import (
             create_encoder_classifier_config,
         )
@@ -67,6 +69,14 @@ class ModelRegistry:
         # Register BART model
         self.register("bart", BartForConditionalGeneration, BartConfig)
         self.register_config_mapping("bart", create_bart_config)
+
+        # Register decoder-only causal model (aliases: decoder_only, decoder).
+        # One causal stack over [problem, solution], as used in the arithmetic
+        # reasoning literature.
+        self.register("decoder_only", DecoderOnlyTransformer, DecoderOnlyConfig)
+        self.register("decoder", DecoderOnlyTransformer, DecoderOnlyConfig)
+        self.register_config_mapping("decoder_only", create_decoder_only_config)
+        self.register_config_mapping("decoder", create_decoder_only_config)
 
         # Register encoder-only classification model (aliases: encoder_classifier,
         # encoder_only). Single-token classification for tasks like parity.

--- a/src/calt/models/decoder_only/__init__.py
+++ b/src/calt/models/decoder_only/__init__.py
@@ -1,0 +1,10 @@
+"""Decoder-only (causal LM) Transformer."""
+
+from .config_mapping import create_decoder_only_config
+from .model import DecoderOnlyConfig, DecoderOnlyTransformer
+
+__all__ = [
+    "DecoderOnlyTransformer",
+    "DecoderOnlyConfig",
+    "create_decoder_only_config",
+]

--- a/src/calt/models/decoder_only/config_mapping.py
+++ b/src/calt/models/decoder_only/config_mapping.py
@@ -1,0 +1,96 @@
+"""
+Config mapping for the decoder-only Transformer.
+
+Converts from unified config format (cfg.model) to DecoderOnlyConfig.
+"""
+
+from omegaconf import DictConfig
+
+from .model import DecoderOnlyConfig
+
+
+def create_decoder_only_config(
+    model_config: DictConfig,
+    tokenizer=None,
+) -> DecoderOnlyConfig:
+    """Create DecoderOnlyConfig from unified config format.
+
+    A decoder-only model has one stack, so the encoder/decoder pairs of the
+    seq2seq configs collapse: ``num_layers``, ``num_heads`` and ``ffn_dim`` are
+    read first, and the decoder-side keys are the fallback. An existing seq2seq
+    config therefore runs unchanged, at half the depth of its 6+6 counterpart.
+
+    Args:
+        model_config (DictConfig): Model configuration from cfg.model (OmegaConf).
+        tokenizer: When provided, vocab_size and the special token ids
+            (pad/eos/bos) are taken from it so generation aligns with decoding.
+
+    Returns:
+        DecoderOnlyConfig: Decoder-only model configuration.
+    """
+    vocab_size = (
+        len(tokenizer.vocab)
+        if tokenizer is not None
+        else getattr(model_config, "vocab_size", 1000)
+    )
+
+    # Align special token IDs with tokenizer so generation (BOS start, EOS stop)
+    # and batch_decode(skip_special_tokens=True) behave correctly.
+    pad_token_id = getattr(model_config, "pad_token_id", None)
+    eos_token_id = getattr(model_config, "eos_token_id", None)
+    bos_token_id = getattr(model_config, "bos_token_id", None)
+    if tokenizer is not None:
+        if pad_token_id is None and tokenizer.pad_token_id is not None:
+            pad_token_id = tokenizer.pad_token_id
+        if eos_token_id is None and tokenizer.eos_token_id is not None:
+            eos_token_id = tokenizer.eos_token_id
+        if bos_token_id is None and tokenizer.bos_token_id is not None:
+            bos_token_id = tokenizer.bos_token_id
+    if pad_token_id is None:
+        pad_token_id = 0
+    if eos_token_id is None:
+        eos_token_id = 1
+    if bos_token_id is None:
+        bos_token_id = 2
+
+    num_layers = getattr(model_config, "num_layers", None)
+    if num_layers is None:
+        num_layers = getattr(model_config, "num_decoder_layers", 6)
+
+    attention_heads = getattr(model_config, "num_heads", None)
+    if attention_heads is None:
+        attention_heads = getattr(
+            model_config,
+            "num_decoder_heads",
+            getattr(model_config, "num_encoder_heads", 8),
+        )
+
+    dim_feedforward = getattr(model_config, "ffn_dim", None)
+    if dim_feedforward is None:
+        dim_feedforward = getattr(
+            model_config,
+            "decoder_ffn_dim",
+            getattr(model_config, "encoder_ffn_dim", 2048),
+        )
+
+    return DecoderOnlyConfig(
+        d_model=model_config.d_model,
+        attention_heads=attention_heads,
+        num_layers=num_layers,
+        dim_feedforward=dim_feedforward,
+        # Problem and solution share one sequence, so the positional table has
+        # to span both; the embedding allocates max_input_len * 2 positions.
+        max_input_len=model_config.max_sequence_length,
+        vocab_size=vocab_size,
+        pad_token_id=pad_token_id,
+        eos_token_id=eos_token_id,
+        bos_token_id=bos_token_id,
+        use_positional_embedding=getattr(
+            model_config, "use_positional_embedding", "generic"
+        ),
+        embedding_layer_norm=getattr(model_config, "embedding_layer_norm", True),
+        dropout=getattr(model_config, "dropout", 0.1),
+        activation=getattr(model_config, "activation", "relu"),
+        init_std=getattr(model_config, "init_std", 0.02),
+        seed=getattr(model_config, "seed", 42),
+    )

--- a/src/calt/models/decoder_only/model.py
+++ b/src/calt/models/decoder_only/model.py
@@ -1,0 +1,439 @@
+"""
+A decoder-only (causal LM) Transformer usable with the Hugging Face Trainer.
+
+This is the generic encoder-decoder model with the encoder removed: a single
+causal self-attention stack over the concatenation of the problem and its
+solution.  The problem part is written into the sequence and carries no loss —
+next-token prediction starts in the middle, at the first solution token —
+because a model asked to reproduce the problem from ``<bos>`` alone could not.
+
+    ids     <bos> 1 3 + 0 8 <eos> <bos> 2 1 <eos>
+            |------- problem -------|--- solution ---|
+    loss                                 ^^^^^^^^^^^^
+
+The model consumes the same collated batch as the seq2seq models
+(``input_ids`` / ``attention_mask`` / ``decoder_input_ids`` / ``labels``) and
+returns predictions and generations aligned with ``labels``, so no other part of
+the pipeline changes.  The ``<bos>`` that opens ``decoder_input_ids`` doubles as
+the separator marking where the answer begins.
+"""
+
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+from transformers import PretrainedConfig, PreTrainedModel
+from transformers.modeling_outputs import CausalLMOutput
+from transformers.utils import logging
+
+from ..positional_embeddings import get_positional_embedding
+
+logger = logging.get_logger(__name__)
+
+
+class DecoderOnlyConfig(PretrainedConfig):
+    """Configuration for the decoder-only Transformer."""
+
+    model_type = "decoder_only"
+
+    def __init__(
+        self,
+        d_model: int = 512,
+        attention_heads: int = 8,
+        num_layers: int = 6,
+        dim_feedforward: int = 2048,
+        dropout: float = 0.1,
+        activation: str = "relu",
+        layer_norm_eps: float = 1e-5,
+        norm_first: bool = True,
+        bias: bool = True,
+        vocab_size: int = 1000,
+        max_input_len: int = 512,
+        pad_token_id: int = 0,
+        eos_token_id: int = 1,
+        bos_token_id: int = 2,
+        use_positional_embedding: str = "generic",
+        embedding_layer_norm: bool = True,
+        init_std: float = 0.02,
+        tie_word_embeddings: bool = False,
+        seed: int = 42,
+        **kwargs,
+    ):
+        """Configure layer sizes, embeddings, and tokenizer metadata.
+
+        Args:
+            d_model (int, optional): Hidden size used across embeddings and blocks.
+            attention_heads (int, optional): Number of attention heads per block.
+            num_layers (int, optional): Number of causal self-attention blocks.
+            dim_feedforward (int, optional): Width of the feed-forward layers.
+            dropout (float, optional): Dropout probability applied in the stack.
+            activation (str, optional): Activation used inside feed-forward blocks.
+            layer_norm_eps (float, optional): Epsilon for layer normalization.
+            norm_first (bool, optional): Whether to apply layer norm before attention.
+            bias (bool, optional): If linear layers include a bias term.
+            vocab_size (int, optional): Vocabulary size for embeddings and head.
+            max_input_len (int, optional): Maximum supported sequence length.
+            pad_token_id (int, optional): Padding token id.
+            eos_token_id (int, optional): End-of-sequence token id.
+            bos_token_id (int, optional): Beginning-of-sequence token id, also the
+                token that opens the solution part of the sequence.
+            use_positional_embedding (str, optional): Positional embedding strategy.
+            embedding_layer_norm (bool, optional): Normalize token+position before
+                the stack, as BART does.
+            init_std (float, optional): Standard deviation for weight init.
+            tie_word_embeddings (bool, optional): Whether to share embed/lm_head.
+            seed (int, optional): Seed used for deterministic initialization.
+            **kwargs: Extra options passed to `PretrainedConfig`.
+        """
+        super().__init__(
+            pad_token_id=pad_token_id,
+            eos_token_id=eos_token_id,
+            bos_token_id=bos_token_id,
+            **kwargs,
+        )
+
+        self.d_model = d_model
+        self.attention_heads = attention_heads
+        self.num_layers = num_layers
+        self.dim_feedforward = dim_feedforward
+        self.dropout = dropout
+        self.activation = activation
+        self.layer_norm_eps = layer_norm_eps
+        self.norm_first = norm_first
+        self.bias = bias
+        self.vocab_size = vocab_size
+        self.max_input_len = max_input_len
+        self.use_positional_embedding = use_positional_embedding
+        self.embedding_layer_norm = embedding_layer_norm
+        self.init_std = init_std
+        self.tie_word_embeddings = tie_word_embeddings
+        self.seed = seed
+
+
+class DecoderOnlyTransformer(PreTrainedModel):
+    """Causal Transformer over ``[problem, solution]``, HF Trainer compatible."""
+
+    config_class = DecoderOnlyConfig
+
+    def __init__(self, config: DecoderOnlyConfig):
+        """Build embedding, causal stack, and language modeling head.
+
+        Args:
+            config (DecoderOnlyConfig): Model hyper-parameters and tokenizer metadata.
+        """
+        super().__init__(config)
+
+        self.config = config
+
+        self.embedding = nn.Embedding(config.vocab_size, config.d_model)
+
+        self.positional_embedding = get_positional_embedding(
+            pe_type=config.use_positional_embedding,
+            d_model=config.d_model,
+            max_len=config.max_input_len * 2,
+        )
+
+        # Same reason as the seq2seq model: without normalizing token+position,
+        # the residual stream enters the stack far smaller than what the layers
+        # add to it and precise value prediction never leaves chance level.
+        self.emb_norm = (
+            nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
+            if getattr(config, "embedding_layer_norm", True)
+            else None
+        )
+
+        # A decoder without cross-attention is exactly an encoder stack driven by
+        # a causal mask, which is what nn.TransformerEncoder provides.
+        layer = nn.TransformerEncoderLayer(
+            d_model=config.d_model,
+            nhead=config.attention_heads,
+            dim_feedforward=config.dim_feedforward,
+            dropout=config.dropout,
+            activation=config.activation,
+            layer_norm_eps=config.layer_norm_eps,
+            batch_first=True,
+            norm_first=config.norm_first,
+            bias=config.bias,
+        )
+        self.transformer = nn.TransformerEncoder(
+            layer,
+            num_layers=config.num_layers,
+            norm=nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
+            if config.norm_first
+            else None,
+        )
+
+        self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
+
+        self.apply(self._init_weights)
+        self.tie_weights()
+        self.seed = config.seed
+        torch.manual_seed(self.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self.seed)
+
+    def _init_weights(self, module):
+        """Apply CALT-specific initialization to supported modules."""
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=self.config.init_std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=self.config.init_std)
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)
+
+    def _compute_embeddings(self, input_ids: torch.LongTensor) -> torch.Tensor:
+        """Compute token embeddings combined with positional embeddings."""
+        embeddings = self.embedding(input_ids)
+
+        if self.positional_embedding is not None:
+            embeddings = self.positional_embedding(embeddings)
+
+        if self.emb_norm is not None:
+            embeddings = self.emb_norm(embeddings)
+
+        return embeddings
+
+    def _generate_causal_mask(self, size: int, device: torch.device) -> torch.Tensor:
+        """Create an upper-triangular mask preventing attention to the future."""
+        return torch.triu(
+            torch.ones(size, size, device=device, dtype=torch.bool), diagonal=1
+        )
+
+    @staticmethod
+    def _lengths(mask: Optional[torch.Tensor], width: int, device) -> torch.Tensor:
+        """Real (non-padded) length per row; the full width when no mask is given."""
+        if mask is None:
+            return torch.full((1,), width, dtype=torch.long, device=device)
+        return mask.to(torch.bool).sum(dim=1)
+
+    def _run_stack(
+        self, ids: torch.LongTensor, key_padding_mask: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Embed and run the causal stack over ``ids``."""
+        embeddings = self._compute_embeddings(ids)
+        causal_mask = self._generate_causal_mask(ids.size(1), ids.device)
+        return self.transformer(
+            embeddings,
+            mask=causal_mask,
+            src_key_padding_mask=key_padding_mask,
+        )
+
+    def _pack(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor],
+        target_ids: torch.LongTensor,
+        target_mask: Optional[torch.Tensor],
+    ) -> tuple[torch.LongTensor, torch.Tensor, torch.Tensor]:
+        """Concatenate problem and solution per row, dropping the problem padding.
+
+        The collator pads the two sides independently, so a plain ``cat`` would
+        leave padding in the middle of the sequence and shift every solution
+        token to a position that depends on the rest of the batch.  Packing keeps
+        the solution starting immediately after the problem's last real token.
+
+        Returns:
+            tuple: packed ids ``(batch, total)``, boolean key padding mask, and
+            the per-row index at which the solution starts.
+        """
+        device = input_ids.device
+        batch, in_width = input_ids.shape
+        tgt_width = target_ids.size(1)
+
+        in_len = self._lengths(attention_mask, in_width, device).expand(batch)
+        tgt_len = self._lengths(target_mask, tgt_width, device).expand(batch)
+
+        total = in_width + tgt_width
+        positions = torch.arange(total, device=device).unsqueeze(0)  # (1, total)
+        start = in_len.unsqueeze(1)  # (batch, 1)
+
+        in_index = positions.clamp(max=in_width - 1).expand(batch, total)
+        tgt_index = (positions - start).clamp(0, tgt_width - 1)
+
+        from_input = positions < start
+        from_target = (positions >= start) & (positions < start + tgt_width)
+
+        packed = torch.where(
+            from_input,
+            input_ids.gather(1, in_index),
+            target_ids.gather(1, tgt_index),
+        )
+        packed = torch.where(
+            from_input | from_target,
+            packed,
+            torch.full_like(packed, self.config.pad_token_id),
+        )
+
+        # Everything past the row's own real content is padding: the tail of the
+        # buffer, and the solution padding the collator added.
+        real = positions < (start + tgt_len.unsqueeze(1))
+        key_padding_mask = ~real
+
+        return packed, key_padding_mask, in_len
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        decoder_input_ids: Optional[torch.LongTensor] = None,
+        decoder_attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        return_dict: Optional[bool] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Run the causal stack over ``[problem, solution]``.
+
+        Args:
+            input_ids (torch.LongTensor | None): Problem token ids.
+            attention_mask (torch.Tensor | None): Mask aligned with `input_ids`.
+            decoder_input_ids (torch.LongTensor | None): Solution inputs, opening
+                with the BOS that marks where the answer begins.
+            decoder_attention_mask (torch.Tensor | None): Mask for the solution.
+            labels (torch.LongTensor | None): Targets aligned with
+                `decoder_input_ids`, padding marked as -100.
+            return_dict (bool | None): Whether to return a dataclass output.
+            **kwargs: Extra arguments kept for HF Trainer compatibility.
+
+        Returns:
+            CausalLMOutput: Loss, and predicted ids aligned with `labels`.
+
+        Raises:
+            ValueError: If either half of the sequence is missing.
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if input_ids is None or decoder_input_ids is None:
+            raise ValueError(
+                "The decoder-only model needs both input_ids (the problem) and "
+                "decoder_input_ids (the solution) to build one causal sequence."
+            )
+
+        packed, key_padding_mask, in_len = self._pack(
+            input_ids, attention_mask, decoder_input_ids, decoder_attention_mask
+        )
+        hidden = self._run_stack(packed, key_padding_mask)
+
+        # Position start+i holds solution token i, so its output predicts
+        # labels[:, i]. Gathering that slice back out keeps predictions the same
+        # shape as labels, which is what the metric and the seq2seq models assume.
+        tgt_width = decoder_input_ids.size(1)
+        offsets = torch.arange(tgt_width, device=packed.device).unsqueeze(0)
+        index = (in_len.unsqueeze(1) + offsets).clamp(max=packed.size(1) - 1)
+        target_hidden = hidden.gather(
+            1, index.unsqueeze(-1).expand(-1, -1, hidden.size(-1))
+        )
+
+        logits = self.lm_head(target_hidden)
+
+        loss = None
+        if labels is not None:
+            loss_fct = nn.CrossEntropyLoss(ignore_index=-100)
+            loss = loss_fct(logits.reshape(-1, logits.size(-1)), labels.reshape(-1))
+
+        if not return_dict:
+            return (loss, logits) if loss is not None else (logits,)
+
+        return CausalLMOutput(
+            loss=loss,
+            # Ids rather than logits, matching the seq2seq model in this package:
+            # the trainer's metric argmaxes only 3-D predictions.
+            logits=torch.argmax(logits, dim=-1),
+            hidden_states=None,
+            attentions=None,
+        )
+
+    def generate(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        max_length: int = 100,
+        num_beams: int = 1,
+        temperature: float = 1.0,
+        do_sample: bool = False,
+        pad_token_id: Optional[int] = None,
+        eos_token_id: Optional[int] = None,
+        **kwargs,
+    ) -> torch.LongTensor:
+        """Continue each problem with its solution, one token at a time.
+
+        Only the generated part is returned, so exact-match evaluation compares
+        it against the labels unchanged; the problem stays in the context.
+
+        Args:
+            input_ids (torch.LongTensor): Problem token ids.
+            attention_mask (torch.Tensor | None): Mask aligned with `input_ids`.
+            max_length (int, optional): Maximum number of tokens to generate.
+            num_beams (int, optional): Reserved for API parity (unused).
+            temperature (float, optional): Sampling temperature.
+            do_sample (bool, optional): Whether to sample instead of argmax.
+            pad_token_id (int | None): Override for padding id.
+            eos_token_id (int | None): Override for end-of-sequence id.
+            **kwargs: Extra keyword arguments for API compatibility.
+
+        Returns:
+            torch.LongTensor: Generated sequences, opening with BOS, in the same
+            layout the seq2seq model returns.
+        """
+        if pad_token_id is None:
+            pad_token_id = self.config.pad_token_id
+        if eos_token_id is None:
+            eos_token_id = self.config.eos_token_id
+
+        device = input_ids.device
+        batch, in_width = input_ids.shape
+        in_len = self._lengths(attention_mask, in_width, device).expand(batch)
+
+        # The answer opens with BOS, so the buffer holds the problem, that BOS,
+        # and room for max_length generated tokens.
+        buffer_width = in_width + 1 + max_length
+        buffer = torch.full(
+            (batch, buffer_width), pad_token_id, dtype=torch.long, device=device
+        )
+        positions = torch.arange(buffer_width, device=device).unsqueeze(0)
+        start = in_len.unsqueeze(1)
+        in_index = positions.clamp(max=in_width - 1).expand(batch, buffer_width)
+        buffer = torch.where(positions < start, input_ids.gather(1, in_index), buffer)
+        buffer.scatter_(1, start, torch.full_like(start, self.config.bos_token_id))
+
+        # Each row writes at its own cursor, since problems differ in length.
+        cursor = in_len + 1
+        finished = torch.zeros(batch, dtype=torch.bool, device=device)
+        generated = 0
+
+        for _ in range(max_length):
+            width = int(cursor.max().item())
+            real = torch.arange(width, device=device).unsqueeze(0) < cursor.unsqueeze(1)
+            hidden = self._run_stack(buffer[:, :width], ~real)
+
+            last = (cursor - 1).view(batch, 1, 1).expand(-1, -1, hidden.size(-1))
+            next_token_logits = self.lm_head(hidden.gather(1, last).squeeze(1))
+
+            if do_sample:
+                next_token_logits = next_token_logits / temperature
+                next_token = torch.multinomial(
+                    torch.softmax(next_token_logits, dim=-1), 1
+                )
+            else:
+                next_token = torch.argmax(next_token_logits, dim=-1, keepdim=True)
+
+            # Keep finished sequences closed by emitting PAD after EOS.
+            next_token[finished.unsqueeze(1)] = pad_token_id
+            finished = finished | (next_token.squeeze(1) == eos_token_id)
+
+            buffer.scatter_(1, cursor.unsqueeze(1), next_token)
+            cursor = cursor + 1
+            generated += 1
+
+            if finished.all():
+                break
+
+        # Cut out the answer only: the BOS at `start` plus what was generated.
+        width = 1 + generated
+        offsets = torch.arange(width, device=device).unsqueeze(0)
+        index = (start + offsets).clamp(max=buffer_width - 1)
+        return buffer.gather(1, index)

--- a/tests/train/test_decoder_only.py
+++ b/tests/train/test_decoder_only.py
@@ -1,0 +1,248 @@
+"""Tests for the decoder-only model.
+
+The model folds the collated seq2seq batch into a single causal sequence, so the
+things worth pinning down are that the fold is faithful (problem padding does not
+leak into the solution's positions), that the loss is only taken on the solution,
+and that generation returns the answer alone.
+"""
+
+import torch
+from omegaconf import OmegaConf
+
+from calt.models import ModelPipeline
+from calt.models.decoder_only.model import DecoderOnlyConfig, DecoderOnlyTransformer
+
+PAD, EOS, BOS = 0, 1, 2
+
+
+def _config(**overrides) -> DecoderOnlyConfig:
+    params = dict(
+        d_model=32,
+        attention_heads=4,
+        num_layers=2,
+        dim_feedforward=64,
+        dropout=0.0,
+        vocab_size=20,
+        max_input_len=64,
+        pad_token_id=PAD,
+        eos_token_id=EOS,
+        bos_token_id=BOS,
+    )
+    params.update(overrides)
+    return DecoderOnlyConfig(**params)
+
+
+def _batch():
+    """Two examples whose problems differ in length, so one row is padded."""
+    input_ids = torch.tensor(
+        [
+            [BOS, 5, 6, 7, EOS],
+            [BOS, 8, 9, EOS, PAD],
+        ]
+    )
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 0],
+        ]
+    )
+    decoder_input_ids = torch.tensor(
+        [
+            [BOS, 11, 12],
+            [BOS, 13, PAD],
+        ]
+    )
+    decoder_attention_mask = torch.tensor(
+        [
+            [1, 1, 1],
+            [1, 1, 0],
+        ]
+    )
+    labels = torch.tensor(
+        [
+            [11, 12, EOS],
+            [13, EOS, -100],
+        ]
+    )
+    return dict(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        decoder_input_ids=decoder_input_ids,
+        decoder_attention_mask=decoder_attention_mask,
+        labels=labels,
+    )
+
+
+def test_forward_shapes_and_loss():
+    """Predictions line up with labels so the trainer's metric can compare them."""
+    model = DecoderOnlyTransformer(_config()).eval()
+    batch = _batch()
+
+    out = model(**batch)
+
+    assert out.logits.shape == batch["labels"].shape
+    assert out.loss is not None and torch.isfinite(out.loss)
+
+
+def test_padding_of_the_problem_does_not_change_the_answer():
+    """A short problem must be scored the same alone as next to a longer one.
+
+    The collator pads the problem and the solution independently, so a naive
+    concatenation would leave padding between them and shift every solution
+    token by an amount that depends on the rest of the batch.
+    """
+    model = DecoderOnlyTransformer(_config()).eval()
+    batch = _batch()
+
+    with torch.no_grad():
+        batched = model(**batch)
+
+        alone = model(
+            input_ids=batch["input_ids"][1:, :4],
+            attention_mask=batch["attention_mask"][1:, :4],
+            decoder_input_ids=batch["decoder_input_ids"][1:, :2],
+            decoder_attention_mask=batch["decoder_attention_mask"][1:, :2],
+            labels=batch["labels"][1:, :2],
+        )
+
+    assert torch.equal(batched.logits[1, :2], alone.logits[0])
+
+
+def test_loss_ignores_the_problem():
+    """Only the solution carries loss; the problem part is context, not target."""
+    model = DecoderOnlyTransformer(_config()).eval()
+    batch = _batch()
+
+    out = model(**batch)
+    out.loss.backward()
+
+    # Every gradient path runs through the solution positions. Changing a
+    # problem token changes the loss (it is context), but no loss term asks the
+    # model to reproduce the problem itself, which is what the shape assertion
+    # above encodes: one prediction per label, none per problem token.
+    assert out.logits.shape == batch["labels"].shape
+    assert model.lm_head.weight.grad is not None
+
+
+def test_generate_returns_only_the_answer():
+    """Generation starts mid-sequence and returns the completion, not the prompt."""
+    model = DecoderOnlyTransformer(_config()).eval()
+    batch = _batch()
+
+    with torch.no_grad():
+        generated = model.generate(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            max_length=4,
+        )
+
+    # BOS opens the answer, as it does in the seq2seq model's output.
+    assert generated.shape[0] == batch["input_ids"].shape[0]
+    assert generated.shape[1] <= 1 + 4
+    assert torch.all(generated[:, 0] == BOS)
+    # No problem token is echoed back into the returned sequence.
+    assert not torch.any(generated[:, 1:] == 5)
+
+
+def test_generate_matches_teacher_forcing():
+    """Greedy decoding reproduces the argmax the forward pass would take."""
+    model = DecoderOnlyTransformer(_config()).eval()
+    batch = _batch()
+
+    with torch.no_grad():
+        forced = model(**batch).logits  # already argmaxed ids
+        generated = model.generate(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            max_length=1,
+        )
+
+    # The first generated token follows the answer-opening BOS, which is exactly
+    # what position 0 of the teacher-forced predictions holds.
+    assert torch.equal(generated[:, 1], forced[:, 0])
+
+
+def test_generate_stops_after_eos():
+    """Once a row emits EOS it only emits padding afterwards."""
+    config = _config()
+    model = DecoderOnlyTransformer(config).eval()
+    # Force EOS: bias the head so EOS always wins.
+    with torch.no_grad():
+        model.lm_head.weight.zero_()
+        model.lm_head.weight[EOS] = 100.0
+
+    batch = _batch()
+    with torch.no_grad():
+        generated = model.generate(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            max_length=5,
+        )
+
+    assert torch.all(generated[:, 1] == EOS)
+    assert torch.all(generated[:, 2:] == PAD)
+
+
+def test_registry_builds_from_model_type():
+    """`model_type: decoder_only` is reachable from an experiment config."""
+    cfg = OmegaConf.create(
+        {
+            "model_type": "decoder_only",
+            "d_model": 32,
+            "num_encoder_layers": 6,
+            "num_encoder_heads": 4,
+            "num_decoder_layers": 2,
+            "num_decoder_heads": 4,
+            "encoder_ffn_dim": 64,
+            "decoder_ffn_dim": 64,
+            "max_sequence_length": 64,
+            "vocab_size": 20,
+        }
+    )
+
+    model = ModelPipeline(cfg, tokenizer=None).build()
+
+    assert isinstance(model, DecoderOnlyTransformer)
+    # A seq2seq config maps onto one stack: the decoder side is what survives.
+    assert model.config.num_layers == 2
+    assert len(model.transformer.layers) == 2
+
+
+def test_alias_decoder_builds_the_same_model():
+    """`model_type: decoder` is accepted as a shorthand."""
+    cfg = OmegaConf.create(
+        {
+            "model_type": "decoder",
+            "d_model": 32,
+            "num_decoder_layers": 2,
+            "num_decoder_heads": 4,
+            "num_encoder_heads": 4,
+            "encoder_ffn_dim": 64,
+            "max_sequence_length": 64,
+            "vocab_size": 20,
+        }
+    )
+
+    model = ModelPipeline(cfg, tokenizer=None).build()
+
+    assert isinstance(model, DecoderOnlyTransformer)
+
+
+def test_num_layers_overrides_the_seq2seq_keys():
+    """An explicit `num_layers` wins over `num_decoder_layers`."""
+    cfg = OmegaConf.create(
+        {
+            "model_type": "decoder_only",
+            "d_model": 32,
+            "num_layers": 4,
+            "num_decoder_layers": 2,
+            "num_encoder_heads": 4,
+            "encoder_ffn_dim": 64,
+            "max_sequence_length": 64,
+            "vocab_size": 20,
+        }
+    )
+
+    model = ModelPipeline(cfg, tokenizer=None).build()
+
+    assert len(model.transformer.layers) == 4


### PR DESCRIPTION
Adds a decoder-only causal model to CALT, requested for the arithmetic experiments: the arithmetic-reasoning literature generally trains decoder-only models rather than encoder-decoders.

## What it is

The generic model with the encoder removed, one causal self-attention stack over the concatenation of the problem and its solution. Prediction starts in the middle: the problem is context and carries no loss, since a model asked to reproduce it from `<bos>` alone could not.

```
ids     <bos> 1 3 + 0 8 <eos> <bos> 2 1 <eos>
        |------- problem -------|--- solution ---|
loss                                 ^^^^^^^^^^^^
```

Cross-checked against the reference implementation in `kawakera-lab/Chain-of-Thought-in-Order`, whose training collator (`GPTDataCollator` in `src/loader/data.py`) masks the prompt the same way.

## Drop-in

Like `model_type: monomial`, it sits on the existing seq2seq data path. It consumes the standard collated batch (`input_ids` / `attention_mask` / `decoder_input_ids` / `labels`) and returns predictions and generations aligned with `labels`, so IO, collator, trainer and metrics are untouched. An existing config runs by changing one line.

The two halves are packed per example, because the collator pads the problem and the solution independently and a plain concatenation would leave padding between them, shifting every solution token to a position that depends on the rest of the batch. `generate()` returns the completion only, so exact-match evaluation compares it against the labels unchanged.

```yaml
model:
  model_type: decoder_only   # alias: decoder
  num_layers: 6
  num_heads: 8
  d_model: 512
  ffn_dim: 2048
  max_sequence_length: 256
```

`num_layers` / `num_heads` / `ffn_dim` fall back to the decoder-side keys of a seq2seq block, so a `generic` config also runs unchanged, at half the depth of its 6+6 counterpart.

## Tests

9 new tests: loss alignment with `labels`, packing invariance (a short problem scored the same alone as next to a longer one), generation returning no prompt tokens, greedy decoding agreeing with teacher forcing, EOS handling, and the registry entry points. Full suite passes at 134.

## Docs

New section in `docs/model_pipeline.md`, plus the `model_type` rows in the supported-types table and in `docs/configuration.md`.