### PR TITLE
Honour gradient_accumulation_steps from the train config

### DIFF
--- a/src/calt/trainer/loader.py
+++ b/src/calt/trainer/loader.py
@@ -171,6 +171,13 @@ class StandardTrainerLoader(TrainerLoader):
             ),
             "per_device_train_batch_size": train_batch_size,
             "per_device_eval_batch_size": test_batch_size,
+            # Lets a long-sequence run keep its effective batch size on a
+            # smaller per-device batch instead of failing with CUDA OOM.
+            "gradient_accumulation_steps": getattr(
+                self.calt_config,
+                "gradient_accumulation_steps",
+                _DEFAULT_TRAINING_ARGS.gradient_accumulation_steps,
+            ),
             "lr_scheduler_type": lr_scheduler_type,
             "max_grad_norm": getattr(
                 self.calt_config, "max_grad_norm", _DEFAULT_TRAINING_ARGS.max_grad_norm


### PR DESCRIPTION
`TrainingArguments` was built without `gradient_accumulation_steps`, so a config setting it was silently ignored and the run trained at the per-device batch size rather than the intended effective one. A long-sequence task that has to drop its per-device batch to fit in memory had no way to get its effective batch back.

Read like the other optional keys, defaulting to the `TrainingArguments` default, so existing configs are unaffected.

Found while packaging the ISSAC experiments: `issac2026_experiments/groebner/configs/train_QQ_lowmem.yaml` sets `gradient_accumulation_steps: 8` on `batch_size: 16`, and would have trained at 16 instead of an effective 128.

36 trainer tests pass.