### PR TITLE
Add monomial decoder-only model

### DIFF
--- a/docs/model_pipeline.md
+++ b/docs/model_pipeline.md
@@ -26,6 +26,7 @@ Models are created via an internal `ModelRegistry`. The following types are regi
 | `encoder_classifier`, `encoder_only` | Encoder-only single-token classification model (see below). |
 | `monomial`, `monomial_transformer` | Encoder–decoder with monomial-structured embedding for C/E expanded-form data (see below). |
 | `decoder_only`, `decoder` | Decoder-only causal Transformer over `[problem, solution]` (see below). |
+| `monomial_decoder_only`, `monomial_decoder` | Decoder-only causal Transformer over monomial positions (see below). |
 
 Set `model_type` in the `model` block of `train.yaml` (e.g. `model_type: generic`). Other keys in the `model` block (e.g. `num_encoder_layers`, `d_model`, `max_sequence_length`) are documented under [Configuration — `model`](configuration.md#trainyaml--model-and-training-modelpipeline-trainerpipeline).
 
@@ -99,6 +100,34 @@ model:
 Like the monomial model, it is a drop-in over the existing seq2seq data path: it consumes the standard collated batch (`input_ids` / `attention_mask` / `decoder_input_ids` / `labels`), packs the two halves per example so the independent padding of the two sides never lands between them, and returns predictions and generations aligned with `labels`. `generate()` returns the completion only, not the prompt, so exact-match evaluation compares it against the labels unchanged. The `<bos>` that opens `decoder_input_ids` doubles as the marker for where the answer begins.
 
 Note that the problem and the solution now share one sequence: `max_sequence_length` has to cover both, since the positional table is sized from it.
+
+## Monomial decoder-only model
+
+`model_type: monomial_decoder_only` (alias `monomial_decoder`) combines the two models above: one causal stack, and one sequence position per monomial. It is the model to use when a polynomial task should be trained decoder-only, or when the two architectures have to be compared on the same input representation.
+
+```
+positions   [C1 E1 E0 +] [C2 E0 E1 <] | ans | [C3 E1 E1 +] [C1 E0 E0 <]
+            |----------- problem -----------|  |------- solution -------|
+loss                                              ^^^^^^^^^^^^^^^^^^^^^^
+```
+
+The learnable **answer marker** between the two halves plays the role the `<bos>` plays in the flat decoder-only model: it is the position whose output predicts the first solution monomial. As there, the problem carries no loss.
+
+```yaml
+model:
+  model_type: monomial_decoder_only   # alias: monomial_decoder
+  num_variables: 2                    # REQUIRED, as for `monomial`
+  num_layers: 6
+  num_heads: 8
+  d_model: 512
+  ffn_dim: 2048
+  max_sequence_length: 512
+  # monomial_separators: ["+", "||"]  # set this if your separator is not "||"
+```
+
+The configuration surface is that of `monomial` for the vocabulary keys and that of `decoder_only` for the architecture keys, so the same config trains either architecture by changing `model_type` alone. Unlike the encoder–decoder monomial model, which keeps independent source and target embedding tables, one stack sees one stream, so problem and solution share a single table.
+
+The data requirements are those of `monomial`: C/E expanded form, and `num_variables` matching the data.
 
 ## Custom embeddings (input and positional)
 

--- a/src/calt/models/__init__.py
+++ b/src/calt/models/__init__.py
@@ -4,6 +4,10 @@ from .generic.model import Transformer, TransformerConfig
 from .input_embeddings import get_input_embedding, register_input_embedding
 from .loader import ModelLoader
 from .monomial.model import MonomialTransformer, MonomialTransformerConfig
+from .monomial_decoder_only.model import (
+    MonomialDecoderOnlyConfig,
+    MonomialDecoderOnlyTransformer,
+)
 from .pipeline import ModelPipeline
 from .positional_embeddings import (
     get_positional_embedding,
@@ -29,6 +33,8 @@ __all__ = [
     "TransformerConfig",
     "MonomialTransformer",
     "MonomialTransformerConfig",
+    "MonomialDecoderOnlyTransformer",
+    "MonomialDecoderOnlyConfig",
     "DecoderOnlyTransformer",
     "DecoderOnlyConfig",
     # Pluggable embeddings (custom input + positional)

--- a/src/calt/models/base.py
+++ b/src/calt/models/base.py
@@ -57,6 +57,13 @@ class ModelRegistry:
         from .generic.model import Transformer, TransformerConfig
         from .monomial.config_mapping import create_monomial_config
         from .monomial.model import MonomialTransformer, MonomialTransformerConfig
+        from .monomial_decoder_only.config_mapping import (
+            create_monomial_decoder_only_config,
+        )
+        from .monomial_decoder_only.model import (
+            MonomialDecoderOnlyConfig,
+            MonomialDecoderOnlyTransformer,
+        )
 
         # Register generic transformer model (aliases: transformer, calt, generic)
         self.register("transformer", Transformer, TransformerConfig)
@@ -96,6 +103,27 @@ class ModelRegistry:
         )
         self.register_config_mapping("monomial", create_monomial_config)
         self.register_config_mapping("monomial_transformer", create_monomial_config)
+
+        # Register the monomial decoder-only model (aliases:
+        # monomial_decoder_only, monomial_decoder). The same monomial positions
+        # and factored heads as above, under one causal stack over
+        # [problem, answer marker, solution].
+        self.register(
+            "monomial_decoder_only",
+            MonomialDecoderOnlyTransformer,
+            MonomialDecoderOnlyConfig,
+        )
+        self.register(
+            "monomial_decoder",
+            MonomialDecoderOnlyTransformer,
+            MonomialDecoderOnlyConfig,
+        )
+        self.register_config_mapping(
+            "monomial_decoder_only", create_monomial_decoder_only_config
+        )
+        self.register_config_mapping(
+            "monomial_decoder", create_monomial_decoder_only_config
+        )
 
     def register(
         self,

--- a/src/calt/models/monomial_decoder_only/__init__.py
+++ b/src/calt/models/monomial_decoder_only/__init__.py
@@ -1,0 +1,13 @@
+from .config_mapping import create_monomial_decoder_only_config
+from .model import (
+    MonomialDecoderOnlyConfig,
+    MonomialDecoderOnlyTransformer,
+    fold_to_grid,
+)
+
+__all__ = [
+    "MonomialDecoderOnlyConfig",
+    "MonomialDecoderOnlyTransformer",
+    "create_monomial_decoder_only_config",
+    "fold_to_grid",
+]

--- a/src/calt/models/monomial_decoder_only/config_mapping.py
+++ b/src/calt/models/monomial_decoder_only/config_mapping.py
@@ -1,0 +1,121 @@
+"""
+Config mapping for the monomial decoder-only model.
+
+Converts the unified config format (cfg.model) into a
+MonomialDecoderOnlyConfig. The vocabulary structure (coefficient / exponent /
+separator token groups) is derived from the tokenizer by the same helpers the
+encoder-decoder monomial model uses, so a config that trains one architecture
+trains the other with a single ``model_type`` change.
+
+Expected extra keys on cfg.model: the same as for ``model_type: monomial``
+(``num_variables`` or ``variables``, optionally ``monomial_separators``,
+``coeff_scale``, ``coeff_noise_std``, ``coeff_loss_weight``).
+"""
+
+from omegaconf import DictConfig
+
+from ..monomial.config_mapping import _coeff_fields, _exp_slots
+from .model import MonomialDecoderOnlyConfig
+
+
+def create_monomial_decoder_only_config(
+    model_config: DictConfig,
+    tokenizer=None,
+) -> MonomialDecoderOnlyConfig:
+    """Create a MonomialDecoderOnlyConfig from cfg.model and the tokenizer."""
+    if tokenizer is None:
+        raise ValueError(
+            "The monomial decoder-only model requires the tokenizer to derive "
+            "its coefficient/exponent/separator token groups."
+        )
+
+    vocab = tokenizer.get_vocab()
+
+    coeff_token_ids = _coeff_fields(vocab)
+    if not coeff_token_ids:
+        raise ValueError(
+            "No coefficient tokens ('C<int>' or 'C<int>_<label>') found in the "
+            "vocabulary. The monomial models require data in C/E expanded form; "
+            "check the lexer/vocab config (range: coefficients)."
+        )
+    exp_token_ids = _exp_slots(vocab, model_config)
+    if not exp_token_ids or not exp_token_ids[0]:
+        raise ValueError(
+            "No exponent tokens ('E<int>') found in the vocabulary. The monomial "
+            "models require data in C/E expanded form; check the lexer/vocab "
+            "config (range: exponents)."
+        )
+
+    separators = getattr(model_config, "monomial_separators", None)
+    if separators is None:
+        separators = [t for t in ("+", "||") if t in vocab]
+    else:
+        missing = [t for t in separators if t not in vocab]
+        if missing:
+            raise ValueError(
+                f"monomial_separators {missing} are not in the vocabulary."
+            )
+    separator_token_ids = [vocab[t] for t in separators]
+
+    pad_token_id = getattr(model_config, "pad_token_id", None)
+    eos_token_id = getattr(model_config, "eos_token_id", None)
+    bos_token_id = getattr(model_config, "bos_token_id", None)
+    if pad_token_id is None and tokenizer.pad_token_id is not None:
+        pad_token_id = tokenizer.pad_token_id
+    if eos_token_id is None and tokenizer.eos_token_id is not None:
+        eos_token_id = tokenizer.eos_token_id
+    if bos_token_id is None and tokenizer.bos_token_id is not None:
+        bos_token_id = tokenizer.bos_token_id
+    if pad_token_id is None or eos_token_id is None or bos_token_id is None:
+        raise ValueError(
+            "The monomial decoder-only model needs pad/eos/bos token ids; the "
+            "tokenizer does not define them and cfg.model does not override them."
+        )
+
+    # One stack, so the encoder/decoder pairs of the seq2seq configs collapse:
+    # the decoder-side keys are the fallback, matching create_decoder_only_config.
+    num_layers = getattr(model_config, "num_layers", None)
+    if num_layers is None:
+        num_layers = getattr(model_config, "num_decoder_layers", 6)
+
+    attention_heads = getattr(model_config, "num_heads", None)
+    if attention_heads is None:
+        attention_heads = getattr(
+            model_config,
+            "num_decoder_heads",
+            getattr(model_config, "num_encoder_heads", 8),
+        )
+
+    dim_feedforward = getattr(model_config, "ffn_dim", None)
+    if dim_feedforward is None:
+        dim_feedforward = getattr(
+            model_config,
+            "decoder_ffn_dim",
+            getattr(model_config, "encoder_ffn_dim", 2048),
+        )
+
+    return MonomialDecoderOnlyConfig(
+        d_model=model_config.d_model,
+        attention_heads=attention_heads,
+        num_layers=num_layers,
+        dim_feedforward=dim_feedforward,
+        max_input_len=model_config.max_sequence_length,
+        vocab_size=len(tokenizer),
+        pad_token_id=pad_token_id,
+        eos_token_id=eos_token_id,
+        bos_token_id=bos_token_id,
+        use_positional_embedding=getattr(
+            model_config, "use_positional_embedding", "generic"
+        ),
+        embedding_layer_norm=getattr(model_config, "embedding_layer_norm", True),
+        coeff_token_ids=coeff_token_ids,
+        exp_token_ids=exp_token_ids,
+        separator_token_ids=separator_token_ids,
+        coeff_scale=getattr(model_config, "coeff_scale", 1.0),
+        coeff_noise_std=getattr(model_config, "coeff_noise_std", 0.0),
+        coeff_loss_weight=getattr(model_config, "coeff_loss_weight", 1.0),
+        dropout=getattr(model_config, "dropout", 0.1),
+        activation=getattr(model_config, "activation", "relu"),
+        init_std=getattr(model_config, "init_std", 0.02),
+        seed=getattr(model_config, "seed", 42),
+    )

--- a/src/calt/models/monomial_decoder_only/model.py
+++ b/src/calt/models/monomial_decoder_only/model.py
@@ -350,12 +350,8 @@ class MonomialDecoderOnlyTransformer(PreTrainedModel):
         src_index = positions.clamp(max=L_src - 1).expand(B, total)
         tgt_index = (positions - start - 1).clamp(0, L_tgt - 1)
 
-        gathered_src = src_grid.gather(
-            1, src_index.unsqueeze(-1).expand(-1, -1, w)
-        )
-        gathered_tgt = tgt_grid.gather(
-            1, tgt_index.unsqueeze(-1).expand(-1, -1, w)
-        )
+        gathered_src = src_grid.gather(1, src_index.unsqueeze(-1).expand(-1, -1, w))
+        gathered_tgt = tgt_grid.gather(1, tgt_index.unsqueeze(-1).expand(-1, -1, w))
 
         packed = torch.where(from_src.unsqueeze(-1), gathered_src, gathered_tgt)
         packed = torch.where(
@@ -608,9 +604,7 @@ class MonomialDecoderOnlyTransformer(PreTrainedModel):
             follow_class = logits["follow"][:, 0].argmax(-1)
             finished = finished | (follow_class == eos_class)
 
-            buffer.scatter_(
-                1, cursor.view(B, 1, 1).expand(-1, -1, w), row
-            )
+            buffer.scatter_(1, cursor.view(B, 1, 1).expand(-1, -1, w), row)
             cursor = cursor + 1
             generated += 1
 

--- a/src/calt/models/monomial_decoder_only/model.py
+++ b/src/calt/models/monomial_decoder_only/model.py
@@ -1,0 +1,626 @@
+"""
+A decoder-only Transformer that reads and writes whole monomials.
+
+This is the monomial-embedding model of ``calt.models.monomial`` with the
+encoder removed: a single causal stack over the concatenation of the problem and
+its solution, both folded to one sequence position per monomial.
+
+    monomials   [C1 E1 E0 +] [C2 E0 E1 <] | ans | [C3 E1 E1 +] [C1 E0 E0 <]
+                |----------- problem -----------|  |------- solution -------|
+    loss                                              ^^^^^^^^^^^^^^^^^^^^^^
+
+Two things are combined here, and both matter for what the model can express:
+
+  - *the monomial embedding* (Kera et al., arXiv 2505.23696): a coefficient, its
+    exponents and the separator that follows them occupy one position instead of
+    ``n_vars + 2``, and each slot reads from its own block of the table so that
+    ``x^3 y^2`` and ``x^2 y^3`` never collapse to the same vector;
+  - *the decoder-only layout*: next-token prediction starts in the middle, at
+    the first solution monomial, because a model asked to reproduce the problem
+    from nothing could not.  The problem part is context and carries no loss.
+
+The learnable answer marker sits between the two halves and plays the role the
+``<bos>`` of the flat decoder-only model plays: it is the position whose output
+predicts the first solution monomial.
+
+Unlike the encoder-decoder monomial model, which keeps independent source and
+target embedding tables, one stack sees one stream here, so problem and solution
+share a single table.
+
+Select it with ``model_type: monomial_decoder_only``.  Like every other model in
+this package it consumes the seq2seq collator's batch unchanged
+(``input_ids`` / ``attention_mask`` / ``decoder_input_ids`` / ``labels``) and
+returns predictions and generations aligned with ``labels``.  The data must be
+in C/E expanded form and ``model.num_variables`` must match it.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from transformers import PretrainedConfig, PreTrainedModel
+from transformers.modeling_outputs import CausalLMOutput
+
+from ..monomial.model import (
+    MonomialDecodeHead,
+    MonomialEmbedding,
+    _build_gid_map,
+    _build_local_map,
+)
+from ..positional_embeddings import get_positional_embedding
+
+
+def fold_to_grid(
+    flat_ids: torch.Tensor, width: int, pad_token_id: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reshape flat token ids (BOS already stripped) into a monomial grid.
+
+    Args:
+        flat_ids (torch.Tensor): ``(batch, seq)`` token ids; every valid sample
+            is ``L * width`` tokens, padding may make ``seq`` longer.
+        width (int): Tokens per monomial.
+        pad_token_id (int): Id used for padding.
+
+    Returns:
+        tuple: grid ``(batch, L, width)`` padded up with ``pad_token_id``, and
+        mask ``(batch, L)`` with True on valid monomial rows.
+    """
+    B, S = flat_ids.shape
+    L = max(1, -(-S // width))  # ceil division, at least one row
+    if L * width > S:
+        pad_cols = flat_ids.new_full((B, L * width - S), pad_token_id)
+        flat_ids = torch.cat([flat_ids, pad_cols], dim=1)
+    grid = flat_ids.reshape(B, L, width)
+    mask = grid[..., 0] != pad_token_id
+    return grid, mask
+
+
+class MonomialDecoderOnlyConfig(PretrainedConfig):
+    """Configuration for the monomial decoder-only model.
+
+    Same vocabulary structure as ``MonomialTransformerConfig`` — the token
+    groups are stored as plain id lists so the config stays JSON-serializable —
+    with the encoder/decoder layer counts replaced by a single ``num_layers``.
+
+    Attributes:
+        coeff_token_ids (list[list[int]]): One ordered id list per coefficient
+            field.
+        exp_token_ids (list[list[int]]): One ordered id list per variable slot.
+        separator_token_ids (list[int]): Ids of the continuation separators in
+            follow-slot order; EOS is appended internally as the last class.
+    """
+
+    model_type = "monomial_decoder_only"
+
+    def __init__(
+        self,
+        d_model: int = 512,
+        attention_heads: int = 8,
+        num_layers: int = 6,
+        dim_feedforward: int = 2048,
+        dropout: float = 0.1,
+        activation: str = "relu",
+        layer_norm_eps: float = 1e-5,
+        norm_first: bool = True,
+        bias: bool = True,
+        vocab_size: int = 1000,
+        max_input_len: int = 512,
+        pad_token_id: int = 0,
+        eos_token_id: int = 1,
+        bos_token_id: int = 2,
+        use_positional_embedding: str = "generic",
+        embedding_layer_norm: bool = True,
+        coeff_token_ids: Optional[list] = None,
+        exp_token_ids: Optional[list] = None,
+        separator_token_ids: Optional[list] = None,
+        coeff_scale: float = 1.0,
+        coeff_noise_std: float = 0.0,
+        coeff_loss_weight: float = 1.0,
+        init_std: float = 0.02,
+        seed: int = 42,
+        **kwargs,
+    ):
+        super().__init__(
+            pad_token_id=pad_token_id,
+            eos_token_id=eos_token_id,
+            bos_token_id=bos_token_id,
+            **kwargs,
+        )
+        self.d_model = d_model
+        self.attention_heads = attention_heads
+        self.num_layers = num_layers
+        self.dim_feedforward = dim_feedforward
+        self.dropout = dropout
+        self.activation = activation
+        self.layer_norm_eps = layer_norm_eps
+        self.norm_first = norm_first
+        self.bias = bias
+        self.vocab_size = vocab_size
+        self.max_input_len = max_input_len
+        self.use_positional_embedding = use_positional_embedding
+        self.embedding_layer_norm = embedding_layer_norm
+        self.coeff_token_ids = coeff_token_ids or [[]]
+        self.exp_token_ids = exp_token_ids or [[]]
+        self.separator_token_ids = separator_token_ids or []
+        self.coeff_scale = coeff_scale
+        self.coeff_noise_std = coeff_noise_std
+        self.coeff_loss_weight = coeff_loss_weight
+        self.init_std = init_std
+        self.seed = seed
+
+    @property
+    def num_coeff_fields(self) -> int:
+        return len(self.coeff_token_ids)
+
+    @property
+    def num_variables(self) -> int:
+        return len(self.exp_token_ids)
+
+    @property
+    def monomial_width(self) -> int:
+        """Tokens per monomial: coeff fields + exponent slots + follow slot."""
+        return self.num_coeff_fields + self.num_variables + 1
+
+    @property
+    def num_follow_classes(self) -> int:
+        """Continuation separators + EOS (always the last class)."""
+        return len(self.separator_token_ids) + 1
+
+
+class MonomialDecoderOnlyTransformer(PreTrainedModel):
+    """Causal Transformer over ``[problem, answer marker, solution]`` monomials."""
+
+    config_class = MonomialDecoderOnlyConfig
+
+    def __init__(self, config: MonomialDecoderOnlyConfig):
+        super().__init__(config)
+        self.config = config
+
+        if not config.coeff_token_ids or not config.coeff_token_ids[0]:
+            raise ValueError(
+                "MonomialDecoderOnlyConfig.coeff_token_ids is empty. Build the "
+                "config with create_monomial_decoder_only_config(cfg.model, "
+                "tokenizer) so the coefficient/exponent token groups are derived "
+                "from the tokenizer."
+            )
+        if not config.exp_token_ids or not config.exp_token_ids[0]:
+            raise ValueError(
+                "MonomialDecoderOnlyConfig.exp_token_ids is empty. Set "
+                "model.num_variables (or model.variables) in the config so the "
+                "exponent slots are known."
+            )
+
+        d = config.d_model
+
+        # One stack, one stream, one table: unlike the encoder-decoder model
+        # there is no separate source side to keep independent.
+        self.emb = MonomialEmbedding(
+            config.vocab_size,
+            d,
+            config.num_coeff_fields,
+            config.num_variables,
+            coeff_scale=config.coeff_scale,
+            coeff_noise_std=config.coeff_noise_std,
+        )
+        # The position between problem and solution. Its output predicts the
+        # first solution monomial, exactly as the flat model's <bos> does.
+        self.answer_emb = nn.Parameter(torch.zeros(1, 1, d))
+
+        self.positional_embedding = get_positional_embedding(
+            pe_type=config.use_positional_embedding,
+            d_model=d,
+            max_len=config.max_input_len * 2,
+        )
+        self.emb_norm = (
+            nn.LayerNorm(d, eps=config.layer_norm_eps)
+            if getattr(config, "embedding_layer_norm", True)
+            else None
+        )
+
+        # A decoder without cross-attention is an encoder stack under a causal
+        # mask, which is what nn.TransformerEncoder provides.
+        layer = nn.TransformerEncoderLayer(
+            d_model=d,
+            nhead=config.attention_heads,
+            dim_feedforward=config.dim_feedforward,
+            dropout=config.dropout,
+            activation=config.activation,
+            layer_norm_eps=config.layer_norm_eps,
+            batch_first=True,
+            norm_first=config.norm_first,
+            bias=config.bias,
+        )
+        self.transformer = nn.TransformerEncoder(
+            layer,
+            num_layers=config.num_layers,
+            norm=nn.LayerNorm(d, eps=config.layer_norm_eps)
+            if config.norm_first
+            else None,
+        )
+
+        self.head = MonomialDecodeHead(
+            [len(ids) for ids in config.coeff_token_ids],
+            [len(ids) for ids in config.exp_token_ids],
+            config.num_follow_classes,
+            d,
+        )
+
+        follow_ids = list(config.separator_token_ids) + [config.eos_token_id]
+        self.register_buffer(
+            "coeff_gid_map",
+            _build_gid_map(config.coeff_token_ids, config.pad_token_id),
+        )
+        self.register_buffer(
+            "exp_gid_map", _build_gid_map(config.exp_token_ids, config.pad_token_id)
+        )
+        self.register_buffer(
+            "follow_gid_map", torch.tensor(follow_ids, dtype=torch.long)
+        )
+        self.register_buffer(
+            "coeff_local_map",
+            _build_local_map(config.coeff_token_ids, config.vocab_size),
+        )
+        self.register_buffer(
+            "exp_local_map", _build_local_map(config.exp_token_ids, config.vocab_size)
+        )
+        self.register_buffer(
+            "follow_local_map", _build_local_map([follow_ids], config.vocab_size)[0]
+        )
+
+        self.apply(self._init_weights)
+        nn.init.normal_(self.answer_emb, std=config.init_std)
+        self.seed = config.seed
+        torch.manual_seed(self.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self.seed)
+
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=self.config.init_std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=self.config.init_std)
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)
+
+    # ------------------------------------------------------------------ #
+    # Folding and alignment                                               #
+    # ------------------------------------------------------------------ #
+
+    def _fold(self, flat_ids: torch.Tensor) -> tuple:
+        return fold_to_grid(
+            flat_ids, self.config.monomial_width, self.config.pad_token_id
+        )
+
+    def _check_alignment(self, grid: torch.Tensor, mask: torch.Tensor, what: str):
+        """Fail fast when sequences are not monomial-aligned.
+
+        Every valid monomial's follow slot must hold a separator or EOS. A stray
+        token there means the data is not in C/E expanded form or
+        ``num_variables`` doesn't match, which would corrupt training silently.
+        """
+        f_local = self.follow_local_map[grid[..., -1]]
+        if bool(((f_local < 0) & mask).any()):
+            raise ValueError(
+                f"{what} is not aligned to monomials of width "
+                f"{self.config.monomial_width} (= {self.config.num_coeff_fields} "
+                f"coefficient field(s) + {self.config.num_variables} exponent "
+                "slot(s) + 1 separator). The monomial decoder-only model requires "
+                "data in C/E expanded form ('C<c> E<e1> .. E<en>' terms joined by "
+                "'+'/'||') and model.num_variables matching the data."
+            )
+
+    # ------------------------------------------------------------------ #
+    # Packing                                                             #
+    # ------------------------------------------------------------------ #
+
+    def _pack(
+        self,
+        src_grid: torch.Tensor,
+        src_mask: torch.Tensor,
+        tgt_grid: torch.Tensor,
+        tgt_mask: torch.Tensor,
+    ) -> tuple:
+        """Concatenate problem and solution per row, dropping problem padding.
+
+        The two halves are folded independently, so a plain ``cat`` would leave
+        padded monomial rows in the middle of the sequence and shift every
+        solution monomial to a position that depends on the rest of the batch.
+
+        Returns:
+            tuple: packed grid ``(batch, total, width)``, boolean key padding
+            mask ``(batch, total)``, and the per-row index of the answer marker.
+        """
+        B, L_src, w = src_grid.shape
+        L_tgt = tgt_grid.size(1)
+        device = src_grid.device
+
+        src_len = src_mask.sum(dim=1)  # (B,)
+        tgt_len = tgt_mask.sum(dim=1)  # (B,)
+
+        total = L_src + 1 + L_tgt
+        positions = torch.arange(total, device=device).unsqueeze(0)  # (1, total)
+        start = src_len.unsqueeze(1)  # (B, 1), index of the answer marker
+
+        from_src = positions < start
+        from_tgt = (positions > start) & (positions <= start + L_tgt)
+
+        src_index = positions.clamp(max=L_src - 1).expand(B, total)
+        tgt_index = (positions - start - 1).clamp(0, L_tgt - 1)
+
+        gathered_src = src_grid.gather(
+            1, src_index.unsqueeze(-1).expand(-1, -1, w)
+        )
+        gathered_tgt = tgt_grid.gather(
+            1, tgt_index.unsqueeze(-1).expand(-1, -1, w)
+        )
+
+        packed = torch.where(from_src.unsqueeze(-1), gathered_src, gathered_tgt)
+        packed = torch.where(
+            (from_src | from_tgt).unsqueeze(-1),
+            packed,
+            torch.full_like(packed, self.config.pad_token_id),
+        )
+
+        # Everything past the row's own content is padding: the tail of the
+        # buffer, and the solution padding folding added.
+        real = positions <= (start + tgt_len.unsqueeze(1))
+        key_padding_mask = ~real
+
+        return packed, key_padding_mask, src_len
+
+    def _embed_packed(
+        self, grid: torch.Tensor, marker_pos: torch.Tensor
+    ) -> torch.Tensor:
+        """Embed a packed monomial grid, overwriting the marker position.
+
+        The ids sitting at the marker position are meaningless (they are
+        whatever padding the packing left there); the learnable answer vector
+        replaces them before positions are added.
+        """
+        embeddings = self.emb(grid)
+        positions = torch.arange(grid.size(1), device=grid.device).unsqueeze(0)
+        is_marker = (positions == marker_pos.unsqueeze(1)).unsqueeze(-1)
+        embeddings = torch.where(
+            is_marker, self.answer_emb.to(embeddings.dtype), embeddings
+        )
+
+        if self.positional_embedding is not None:
+            embeddings = self.positional_embedding(embeddings)
+        # Same normalization BART applies before its stack; without it the
+        # residual stream enters the transformer far smaller than what the
+        # layers add to it.
+        if self.emb_norm is not None:
+            embeddings = self.emb_norm(embeddings)
+        return embeddings
+
+    @staticmethod
+    def _causal_mask(size: int, device: torch.device) -> torch.Tensor:
+        return torch.triu(
+            torch.ones(size, size, device=device, dtype=torch.bool), diagonal=1
+        )
+
+    def _run_stack(
+        self,
+        grid: torch.Tensor,
+        marker_pos: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        embeddings = self._embed_packed(grid, marker_pos)
+        causal = self._causal_mask(grid.size(1), grid.device)
+        return self.transformer(
+            embeddings, mask=causal, src_key_padding_mask=key_padding_mask
+        )
+
+    # ------------------------------------------------------------------ #
+    # Loss                                                                #
+    # ------------------------------------------------------------------ #
+
+    def _gid_to_local(self, tgt_grid: torch.Tensor) -> tuple:
+        k, n_vars = self.config.num_coeff_fields, self.config.num_variables
+        c_local = torch.stack(
+            [self.coeff_local_map[j][tgt_grid[..., j]] for j in range(k)], dim=-1
+        )
+        e_local = torch.stack(
+            [self.exp_local_map[v][tgt_grid[..., k + v]] for v in range(n_vars)],
+            dim=-1,
+        )
+        f_local = self.follow_local_map[tgt_grid[..., -1]]
+        return c_local, e_local, f_local
+
+    def _compute_loss(
+        self,
+        logits: dict,
+        c_local: torch.Tensor,
+        e_local: torch.Tensor,
+        f_local: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Factored cross-entropy, averaged over valid solution monomials."""
+        B, T = f_local.shape
+        ce = nn.CrossEntropyLoss(reduction="none", ignore_index=-1)
+
+        step_loss = torch.zeros(B, T, device=f_local.device)
+        for j, logit_j in enumerate(logits["coeffs"]):
+            step_loss = step_loss + self.config.coeff_loss_weight * ce(
+                logit_j.reshape(B * T, -1), c_local[..., j].reshape(B * T)
+            ).view(B, T)
+        for v in range(e_local.size(-1)):
+            step_loss = step_loss + ce(
+                logits["exps"][:, :, v, :].reshape(B * T, -1),
+                e_local[..., v].reshape(B * T),
+            ).view(B, T)
+        step_loss = step_loss + ce(
+            logits["follow"].reshape(B * T, -1), f_local.reshape(B * T)
+        ).view(B, T)
+
+        step_loss = step_loss * mask.to(step_loss.dtype)
+        return step_loss.sum() / mask.sum().clamp(min=1)
+
+    def _predicted_grid(self, logits: dict) -> torch.Tensor:
+        """Argmax each head and map local indices back to token ids: (B, T, w)."""
+        k = self.config.num_coeff_fields
+        parts = [
+            self.coeff_gid_map[j][logits["coeffs"][j].argmax(-1)] for j in range(k)
+        ]
+        exp_local = logits["exps"].argmax(-1)
+        parts += [
+            self.exp_gid_map[v][exp_local[..., v]]
+            for v in range(self.config.num_variables)
+        ]
+        parts.append(self.follow_gid_map[logits["follow"].argmax(-1)])
+        return torch.stack(parts, dim=-1)
+
+    # ------------------------------------------------------------------ #
+    # Forward / generate                                                  #
+    # ------------------------------------------------------------------ #
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        decoder_input_ids: Optional[torch.LongTensor] = None,
+        decoder_attention_mask: Optional[torch.Tensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        return_dict: Optional[bool] = None,
+        **kwargs,
+    ):
+        if input_ids is None:
+            raise ValueError("input_ids must be provided")
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        # input_ids = [BOS, content..., EOS, PAD...]; the content+EOS part is
+        # monomial-aligned, so strip BOS and fold.
+        src_grid, src_mask = self._fold(input_ids[:, 1:])
+        self._check_alignment(src_grid, src_mask, "input_ids")
+
+        # labels (= target without BOS, with EOS, -100 on padding) is already
+        # the monomial-aligned view of the target; prefer it over
+        # decoder_input_ids so teacher forcing and loss share one grid.
+        if labels is not None:
+            tgt_flat = labels.masked_fill(labels == -100, self.config.pad_token_id)
+        elif decoder_input_ids is not None:
+            tgt_flat = decoder_input_ids[:, 1:]
+        else:
+            raise ValueError("Either labels or decoder_input_ids must be provided")
+        tgt_grid, tgt_mask = self._fold(tgt_flat)
+        self._check_alignment(tgt_grid, tgt_mask, "labels")
+
+        packed, key_padding_mask, src_len = self._pack(
+            src_grid, src_mask, tgt_grid, tgt_mask
+        )
+        hidden = self._run_stack(packed, src_len, key_padding_mask)
+
+        # The marker sits at src_len and predicts solution monomial 0; solution
+        # monomial j sits at src_len+1+j and predicts j+1. Gathering src_len+j
+        # for j in [0, L_tgt) therefore lines predictions up with tgt_grid.
+        L_tgt = tgt_grid.size(1)
+        offsets = torch.arange(L_tgt, device=packed.device).unsqueeze(0)
+        index = (src_len.unsqueeze(1) + offsets).clamp(max=packed.size(1) - 1)
+        target_hidden = hidden.gather(
+            1, index.unsqueeze(-1).expand(-1, -1, hidden.size(-1))
+        )
+        logits = self.head(target_hidden)
+
+        loss = None
+        if labels is not None:
+            c_local, e_local, f_local = self._gid_to_local(tgt_grid)
+            loss = self._compute_loss(logits, c_local, e_local, f_local, tgt_mask)
+
+        # Flatten predictions back to token ids in the labels' shape so the
+        # trainer's token-accuracy / success-rate metrics work unchanged.
+        pred_flat = self._predicted_grid(logits).reshape(hidden.size(0), -1)
+        if labels is not None:
+            pred_flat = pred_flat[:, : labels.size(1)]
+
+        if not return_dict:
+            return (loss, pred_flat) if loss is not None else (pred_flat,)
+
+        return CausalLMOutput(loss=loss, logits=pred_flat)
+
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        max_length: int = 512,
+        pad_token_id: Optional[int] = None,
+        eos_token_id: Optional[int] = None,
+        **kwargs,
+    ) -> torch.LongTensor:
+        """Greedy monomial-level continuation, returned as flat token ids.
+
+        Only the generated part is returned, opening with BOS, so the existing
+        exact-match evaluation (``batch_decode(skip_special_tokens=True)``)
+        compares it against the labels unchanged. ``max_length`` counts flat
+        tokens, like the other models in this package.
+        """
+        self.eval()
+        cfg = self.config
+        if pad_token_id is None:
+            pad_token_id = cfg.pad_token_id
+
+        src_grid, src_mask = self._fold(input_ids[:, 1:])
+        self._check_alignment(src_grid, src_mask, "input_ids")
+
+        B, L_src, w = src_grid.shape
+        device = input_ids.device
+        eos_class = cfg.num_follow_classes - 1
+        max_monomials = max(1, (max_length - 1) // w)
+
+        src_len = src_mask.sum(dim=1)  # (B,), also the marker position
+
+        # The buffer holds the problem, the answer marker, and room for the
+        # generated monomials. Each row writes at its own cursor, since problems
+        # differ in length.
+        total = L_src + 1 + max_monomials
+        positions = torch.arange(total, device=device).unsqueeze(0)
+        start = src_len.unsqueeze(1)
+        src_index = positions.clamp(max=L_src - 1).expand(B, total)
+        buffer = torch.full(
+            (B, total, w), pad_token_id, dtype=torch.long, device=device
+        )
+        buffer = torch.where(
+            (positions < start).unsqueeze(-1),
+            src_grid.gather(1, src_index.unsqueeze(-1).expand(-1, -1, w)),
+            buffer,
+        )
+
+        cursor = src_len + 1  # first free slot, just past the marker
+        finished = torch.zeros(B, dtype=torch.bool, device=device)
+        generated = 0
+
+        for _ in range(max_monomials):
+            width = int(cursor.max().item())
+            real = torch.arange(width, device=device).unsqueeze(0) < cursor.unsqueeze(1)
+            hidden = self._run_stack(buffer[:, :width], src_len, ~real)
+
+            last = (cursor - 1).view(B, 1, 1).expand(-1, -1, hidden.size(-1))
+            logits = self.head(hidden.gather(1, last))
+            row = self._predicted_grid(logits)  # (B, 1, w)
+
+            # Keep finished rows closed by emitting PAD monomials.
+            row[finished] = pad_token_id
+            follow_class = logits["follow"][:, 0].argmax(-1)
+            finished = finished | (follow_class == eos_class)
+
+            buffer.scatter_(
+                1, cursor.view(B, 1, 1).expand(-1, -1, w), row
+            )
+            cursor = cursor + 1
+            generated += 1
+
+            if bool(finished.all()):
+                break
+
+        # Cut out the answer only: what was written past the marker.
+        offsets = torch.arange(generated, device=device).unsqueeze(0)
+        index = (start + 1 + offsets).clamp(max=total - 1)
+        answer = buffer.gather(1, index.unsqueeze(-1).expand(-1, -1, w))
+
+        bos_col = torch.full((B, 1), cfg.bos_token_id, dtype=torch.long, device=device)
+        return torch.cat([bos_col, answer.reshape(B, -1)], dim=1)

--- a/tests/train/test_monomial_decoder_only.py
+++ b/tests/train/test_monomial_decoder_only.py
@@ -1,0 +1,331 @@
+"""Tests for the monomial decoder-only model (model_type=monomial_decoder_only).
+
+Covers:
+  - create_monomial_decoder_only_config reuses the monomial vocabulary
+    derivation and collapses the seq2seq layer keys onto one stack.
+  - ModelRegistry resolves the new model_type and its monomial_decoder alias.
+  - forward() consumes the standard seq2seq collator batch, returns a scalar
+    loss and flat predicted token ids in the labels' shape.
+  - Packing: a problem scored next to a longer one is scored the same as alone,
+    i.e. no padding is left between the problem and the answer marker.
+  - Misaligned data (wrong num_variables) raises instead of training silently.
+  - generate() continues from the marker, returns only the answer, stops after
+    EOS, and agrees with what teacher forcing would predict.
+  - A tiny model memorizes a two-sample dataset.
+  - save_pretrained / from_pretrained round-trips the vocabulary structure.
+"""
+
+import torch
+from omegaconf import OmegaConf
+
+from calt.io.base import StandardDataCollator
+from calt.io.tokenizer import get_tokenizer
+from calt.io.vocabulary.config import VocabConfig
+from calt.models.base import ModelRegistry
+from calt.models.monomial_decoder_only import (
+    MonomialDecoderOnlyTransformer,
+    create_monomial_decoder_only_config,
+)
+
+N_VARS = 2
+WIDTH = 1 + N_VARS + 1  # 1 coeff field + n_vars exponents + follow slot
+
+# Two-variable toy task in C/E expanded form. The first sample has the longer
+# problem, so the second one exercises the packing when batched next to it.
+SAMPLES = [
+    {"input": "C3 E1 E0 + C2 E0 E1 || C1 E0 E0", "target": "C5 E1 E1"},
+    {"input": "C-4 E2 E0 || C2 E1 E1", "target": "C-2 E2 E1 + C1 E0 E0"},
+]
+
+
+def _tokenizer():
+    vocab = (
+        [f"C{i}" for i in range(-9, 10)] + [f"E{i}" for i in range(0, 4)] + ["+", "||"]
+    )
+    return get_tokenizer(VocabConfig(vocab=vocab, special_tokens={}))
+
+
+def _model_cfg(**overrides):
+    cfg = {
+        "model_type": "monomial_decoder_only",
+        "d_model": 32,
+        "num_encoder_heads": 4,
+        "num_encoder_layers": 1,
+        "num_decoder_layers": 1,
+        "encoder_ffn_dim": 64,
+        "max_sequence_length": 64,
+        "num_variables": N_VARS,
+        "dropout": 0.0,
+    }
+    cfg.update(overrides)
+    return OmegaConf.create(cfg)
+
+
+def _batch(tokenizer, samples=SAMPLES):
+    return StandardDataCollator(tokenizer)(samples)
+
+
+def _build_model(**overrides):
+    tokenizer = _tokenizer()
+    config = create_monomial_decoder_only_config(_model_cfg(**overrides), tokenizer)
+    return MonomialDecoderOnlyTransformer(config), tokenizer
+
+
+# --------------------------------------------------------------------------- #
+# Config mapping                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_config_mapping_derives_structure():
+    tokenizer = _tokenizer()
+    config = create_monomial_decoder_only_config(_model_cfg(), tokenizer)
+    vocab = tokenizer.get_vocab()
+
+    assert config.monomial_width == WIDTH
+    assert config.num_coeff_fields == 1
+    assert config.coeff_token_ids[0] == [vocab[f"C{i}"] for i in range(-9, 10)]
+    assert config.num_variables == N_VARS
+    exp_ids = [vocab[f"E{i}"] for i in range(0, 4)]
+    assert config.exp_token_ids == [exp_ids, exp_ids]
+    assert config.separator_token_ids == [vocab["+"], vocab["||"]]
+    assert config.num_follow_classes == 3
+    assert config.pad_token_id == tokenizer.pad_token_id
+    assert config.eos_token_id == tokenizer.eos_token_id
+
+
+def test_num_layers_overrides_the_seq2seq_keys():
+    """One stack: num_layers wins, the decoder-side key is the fallback."""
+    tokenizer = _tokenizer()
+    fallback = create_monomial_decoder_only_config(
+        _model_cfg(num_decoder_layers=3), tokenizer
+    )
+    explicit = create_monomial_decoder_only_config(
+        _model_cfg(num_layers=2, num_decoder_layers=3), tokenizer
+    )
+    assert fallback.num_layers == 3
+    assert explicit.num_layers == 2
+
+
+def test_config_mapping_requires_num_variables():
+    cfg = _model_cfg()
+    del cfg.num_variables
+    try:
+        create_monomial_decoder_only_config(cfg, _tokenizer())
+        assert False, "expected ValueError for missing num_variables"
+    except ValueError as e:
+        assert "num_variables" in str(e)
+
+
+def test_config_mapping_requires_tokenizer():
+    try:
+        create_monomial_decoder_only_config(_model_cfg(), None)
+        assert False, "expected ValueError for missing tokenizer"
+    except ValueError as e:
+        assert "tokenizer" in str(e)
+
+
+# --------------------------------------------------------------------------- #
+# Registry                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_resolves_monomial_decoder_only():
+    tokenizer = _tokenizer()
+    registry = ModelRegistry()
+    for name in ("monomial_decoder_only", "monomial_decoder"):
+        model = registry.create_from_config(
+            _model_cfg(model_type=name), tokenizer, model_name=name
+        )
+        assert isinstance(model, MonomialDecoderOnlyTransformer)
+
+
+# --------------------------------------------------------------------------- #
+# Forward                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_forward_loss_and_flat_predictions():
+    model, tokenizer = _build_model()
+    batch = _batch(tokenizer)
+    out = model(**batch)
+
+    assert out.loss is not None
+    assert out.loss.dim() == 0
+    assert out.loss.requires_grad
+    assert torch.isfinite(out.loss)
+    # One prediction per label token, none per problem token: the problem is
+    # context and carries no loss.
+    assert out.logits.shape == batch["labels"].shape
+    assert out.logits.dtype == torch.long
+
+
+def test_padding_of_the_problem_does_not_change_the_answer():
+    """A short problem must be scored the same alone as next to a longer one.
+
+    Problem and solution are folded independently, so a naive concatenation
+    would leave padded monomial rows between them and shift every solution
+    monomial by an amount that depends on the rest of the batch.
+    """
+    model, tokenizer = _build_model()
+    model.eval()
+
+    with torch.no_grad():
+        batched = model(**_batch(tokenizer))
+        alone = model(**_batch(tokenizer, [SAMPLES[1]]))
+
+    width = alone.logits.size(1)
+    assert torch.equal(batched.logits[1, :width], alone.logits[0])
+
+
+def test_misaligned_data_raises():
+    # A model expecting 3 variables folds 2-variable data off-grid: separators
+    # land outside the follow slot and the alignment check must fire.
+    model, tokenizer = _build_model(num_variables=3)
+    batch = _batch(tokenizer)
+    try:
+        model(**batch)
+        assert False, "expected ValueError for misaligned data"
+    except ValueError as e:
+        assert "expanded form" in str(e)
+
+
+# --------------------------------------------------------------------------- #
+# Generation                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_generate_is_flat_and_monomial_aligned():
+    model, tokenizer = _build_model()
+    model.eval()
+    batch = _batch(tokenizer)
+    generated = model.generate(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        max_length=64,
+    )
+
+    assert generated.dtype == torch.long
+    assert (generated[:, 0] == model.config.bos_token_id).all()
+    assert (generated.size(1) - 1) % WIDTH == 0
+
+    follow_ids = set(model.config.separator_token_ids) | {model.config.eos_token_id}
+    for row in generated:
+        grid = row[1:].reshape(-1, WIDTH)
+        seen_eos = False
+        for monomial in grid:
+            if seen_eos:
+                assert (monomial == model.config.pad_token_id).all()
+            else:
+                assert int(monomial[-1]) in follow_ids
+                seen_eos = int(monomial[-1]) == model.config.eos_token_id
+
+    tokenizer.batch_decode(
+        generated, skip_special_tokens=True, clean_up_tokenization_spaces=True
+    )
+
+
+def test_generate_matches_teacher_forcing():
+    """The first generated monomial is the one teacher forcing predicts."""
+    model, tokenizer = _build_model()
+    model.eval()
+    batch = _batch(tokenizer)
+
+    with torch.no_grad():
+        forced = model(**batch).logits  # already argmaxed flat ids
+        generated = model.generate(
+            input_ids=batch["input_ids"],
+            attention_mask=batch["attention_mask"],
+            max_length=1 + WIDTH,
+        )
+
+    # Position 0 of the teacher-forced predictions is the monomial the answer
+    # marker predicts, i.e. exactly the first one generation emits.
+    assert torch.equal(generated[:, 1 : 1 + WIDTH], forced[:, :WIDTH])
+
+
+def test_generate_stops_after_eos():
+    """Once a row emits the EOS follow class it only emits PAD monomials."""
+    model, tokenizer = _build_model()
+    model.eval()
+    batch = _batch(tokenizer)
+
+    generated = model.generate(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        max_length=64,
+    )
+
+    for row in generated:
+        grid = row[1:].reshape(-1, WIDTH)
+        follows = grid[:, -1]
+        eos_at = (follows == model.config.eos_token_id).nonzero()
+        if eos_at.numel():
+            first = int(eos_at[0])
+            assert (grid[first + 1 :] == model.config.pad_token_id).all()
+
+
+# --------------------------------------------------------------------------- #
+# Learning smoke test                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_tiny_model_memorizes_two_samples():
+    torch.manual_seed(0)
+    model, tokenizer = _build_model()
+    batch = _batch(tokenizer)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=3e-3)
+    model.train()
+    first_loss = None
+    for _ in range(200):
+        optimizer.zero_grad()
+        out = model(**batch)
+        out.loss.backward()
+        optimizer.step()
+        if first_loss is None:
+            first_loss = out.loss.item()
+
+    assert out.loss.item() < 0.1 * first_loss
+
+    model.eval()
+    generated = model.generate(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        max_length=64,
+    )
+    texts = tokenizer.batch_decode(
+        generated, skip_special_tokens=True, clean_up_tokenization_spaces=True
+    )
+    assert [t.strip() for t in texts] == [s["target"] for s in SAMPLES]
+
+    # EOS-terminated generations decode to well-formed expanded form:
+    # re-encoding them must pass the model's own alignment check.
+    reencoded = _batch(tokenizer, [{"input": t, "target": t} for t in texts])
+    model(**reencoded)  # would raise if misaligned
+
+
+# --------------------------------------------------------------------------- #
+# Serialization                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_save_load_roundtrip(tmp_path):
+    model, tokenizer = _build_model()
+    batch = _batch(tokenizer)
+    model.eval()
+    before = model.generate(
+        input_ids=batch["input_ids"], attention_mask=batch["attention_mask"]
+    )
+
+    model.save_pretrained(tmp_path)
+    reloaded = MonomialDecoderOnlyTransformer.from_pretrained(tmp_path)
+    reloaded.eval()
+
+    assert reloaded.config.coeff_token_ids == model.config.coeff_token_ids
+    assert reloaded.config.exp_token_ids == model.config.exp_token_ids
+    assert reloaded.config.separator_token_ids == model.config.separator_token_ids
+
+    after = reloaded.generate(
+        input_ids=batch["input_ids"], attention_mask=batch["attention_mask"]
+    )
+    assert torch.equal(before, after)


### PR DESCRIPTION
Adds `model_type: monomial_decoder_only` (alias `monomial_decoder`), answering the optional request to make the monomial embedding usable outside the encoder-decoder model.

It is the monomial model with the encoder removed: one causal stack over `[problem, answer marker, solution]`, one sequence position per monomial, and the same factored coefficient/exponent/separator heads.

```
positions   [C1 E1 E0 +] [C2 E0 E1 <] | ans | [C3 E1 E1 +] [C1 E0 E0 <]
            |----------- problem -----------|  |------- solution -------|
loss                                              ^^^^^^^^^^^^^^^^^^^^^^
```

The learnable answer marker plays the role the `<bos>` plays in the flat decoder-only model: it is the position whose output predicts the first solution monomial. As there, the problem is context and carries no loss.

Notes:

- The configuration surface is that of `monomial` for the vocabulary keys and that of `decoder_only` for the architecture keys, so the same config trains either architecture by changing `model_type` alone.
- One stack sees one stream, so problem and solution share a single embedding table, unlike the encoder-decoder model which keeps them independent.
- Drop-in over the existing data path: it consumes the standard collated batch and returns predictions and generations aligned with `labels`, so metrics and exact-match evaluation are unchanged.

13 tests in `tests/train/test_monomial_decoder_only.py`, covering the config mapping, the registry aliases, the loss and prediction shapes, packing (a short problem is scored the same alone as next to a longer one), the alignment check, generation against teacher forcing, EOS handling, a memorization smoke test, and save/load.

Encoder-only is not covered here. The monomial embedding folds `n_vars + 2` tokens into one position, so it changes the sequence length, which `encoder_classifier` does not handle, and its single-token target gives the factored heads nothing to do. Happy to do it if wanted, but it needs a design decision first.
